### PR TITLE
Bugfix for Act out of jump and add some act out of airborne

### DIFF
--- a/ASM/training-mode/Globals.s
+++ b/ASM/training-mode/Globals.s
@@ -593,7 +593,7 @@ InitSettings:
     .set OSD.Miscellaneous, 15
     .set OSD.ActOoWait, 16
     .set OSD.CrouchCancel, 17
-    .set OSD.ActOoJump, 18
+    .set OSD.ActOoAirborne, 18
     .set OSD.ActOoJumpSquat, 19
     .set OSD.Fastfall, 20
     .set OSD.FrameAdvantage, 21

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of DoubleJump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of DoubleJump.asm
@@ -1,16 +1,15 @@
     # To be inserted at 800cc570
     .include "../../Globals.s"
 
-    .set playerdata, 30
     .set player, 29
 
     backup
 
     # fulfill requirements of the static function before branching
-    mr r4, r29             # store player to r4
-    bl Text                # store the address of OSD text to r6
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
     mflr r6
-    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
 
     branchl r12, 0x8000550c
     b Exit

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of Drop.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of Drop.asm
@@ -1,0 +1,24 @@
+    # To be inserted at 8009a350
+    .include "../../Globals.s"
+
+    .set player, 31
+
+    backup
+
+    # fulfill requirements of the static function before branching
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
+
+    branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Aerial OoDrop\nFrame %d"
+    .align 2
+
+Exit:
+    restore
+    cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of Fall.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of Fall.asm
@@ -1,0 +1,26 @@
+    # To be inserted at 800ccb40
+    # This ASM is injected to "800CCAAC:Fighter_IASACheck_AllAerial" function which is called from some air action states' IASA function.
+    # So this can affect to other action states' IASA besides "Fall".
+    .include "../../Globals.s"
+
+    .set player, 31
+
+    backup
+
+    # fulfill requirements of the static function before branching
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
+
+    branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Aerial OoFall\nFrame %d"
+    .align 2
+
+Exit:
+    restore
+    cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Aerial Out of Jump.asm
@@ -1,16 +1,15 @@
     # To be inserted at 800cb3a8
     .include "../../Globals.s"
 
-    .set playerdata, 31
     .set player, 30
 
     backup
 
     # fulfill requirements of the static function before branching
-    mr r4, r30             # store player to r4
-    bl Text                # store the address of OSD text to r6
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
     mflr r6
-    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
 
     branchl r12, 0x8000550c
     b Exit

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Display Act OoAirborne Frame Count - Static Function.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Display Act OoAirborne Frame Count - Static Function.asm
@@ -20,7 +20,7 @@
     beq Exit
 
     # CHECK IF ENABLED
-    li r0, OSD.ActOoJump
+    li r0, OSD.ActOoAirborne
     lwz r4, -0x77C0(r13)
     lwz r4, 0x1F24(r4)
     li r3, 1
@@ -37,6 +37,9 @@ CheckForFollower:
 
 CheckForPreviousActionState:
     lhz r3, TM_OneASAgo(playerdata)
+    lhz r7, TM_FramesinOneASAgo(playerdata)
+    cmpwi r3, ASID_Pass
+    beq CheckForPreviousFrame
     cmpwi r3, ASID_JumpF
     beq PreviousStateIsJump
     cmpwi r3, ASID_JumpB
@@ -57,15 +60,14 @@ CheckForPreviousActionState:
 
 PreviousStateIsJump:
     lfs f1, 0x150(playerdata)  # get jump_v_initial_velocity
-    b CheckForCutoffFrames
+    b CheckForCutoffFramesForOoJump
 
 PreviousStateIsDoubleJump:
     lfs f1, 0x150(playerdata)  # get jump_v_initial_velocity
     lfs f2, 0x160(playerdata)  # get air_jump_v_multiplier
     fmuls f1, f1, f2           # calculate double jump vertical initial velocity
 
-CheckForCutoffFrames:
-    lhz r7, TM_FramesinOneASAgo(playerdata)
+CheckForCutoffFramesForOoJump:
     # Disable OSD if the act is after frames to reach the peak of fighter's jump (+ some additional frames)
     lfs f2, 0x16C(playerdata)  # get gravity
     fdivs f1, f1, f2           # calculate frames to reach the peak of fighter's jump

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Display Act OoAirborne Frame Count - Static Function.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Display Act OoAirborne Frame Count - Static Function.asm
@@ -40,6 +40,8 @@ CheckForPreviousActionState:
     lhz r7, TM_FramesinOneASAgo(playerdata)
     cmpwi r3, ASID_Pass
     beq CheckForPreviousFrame
+    cmpwi r3, ASID_Fall
+    beq CheckForNecessarySituationForOoFall
     cmpwi r3, ASID_JumpF
     beq PreviousStateIsJump
     cmpwi r3, ASID_JumpB
@@ -57,6 +59,7 @@ CheckForPreviousActionState:
     cmpwi r3, 0x159 # last(5th) aerial jump
     bgt Exit
     b PreviousStateIsDoubleJump
+
 
 PreviousStateIsJump:
     lfs f1, 0x150(playerdata)  # get jump_v_initial_velocity
@@ -77,6 +80,31 @@ CheckForCutoffFramesForOoJump:
     addi r4, r4, 0x5           # add some frames
     cmpw r7, r4
     bgt Exit
+    b CheckForPreviousFrame
+
+
+CheckForNecessarySituationForOoFall:
+    cmpwi r7, 10  # Cutoff by frames
+    bgt Exit
+    # Cutoff by action states before fall which don't need OSD
+    lhz r3, TM_TwoASAgo(playerdata)
+    cmpwi r3, ASID_JumpF
+    beq Exit
+    cmpwi r3, ASID_JumpB
+    beq Exit
+    cmpwi r3, ASID_AttackAirN
+    beq Exit
+    cmpwi r3, ASID_AttackAirF
+    beq Exit
+    cmpwi r3, ASID_AttackAirB
+    beq Exit
+    cmpwi r3, ASID_AttackAirHi
+    beq Exit
+    cmpwi r3, ASID_AttackAirLw
+    beq Exit
+    cmpwi r3, ASID_BarrelCannonWait  # for ignoring special moves mainly
+    bgt Exit
+    b CheckForPreviousFrame
 
 
 CheckForPreviousFrame:

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/DoubleJump Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/DoubleJump Out of Jump.asm
@@ -1,16 +1,15 @@
     # To be inserted at 800cb400
     .include "../../Globals.s"
 
-    .set playerdata, 31
     .set player, 30
 
     backup
 
     # fulfill requirements of the static function before branching
-    mr r4, r30                 # store player to r4
+    mr r4, player              # store player to r4
     bl Text                    # store the address of OSD text to r6
     mflr r6
-    li r10, OSD.Miscellaneous  # store the OSD kind ID to r10 / Originally OSD.ActOoJump is natural, but use other ID to show at the same time as Aerial OoJump for fighters with DoubleJump cancel techniques
+    li r10, OSD.Miscellaneous  # store the OSD kind ID to r10 / Originally OSD.ActOoAirborne is natural, but use other ID to show at the same time as Aerial OoJump for fighters with DoubleJump cancel techniques
 
     branchl r12, 0x8000550c
     b Exit

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of DoubleJump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of DoubleJump.asm
@@ -1,16 +1,15 @@
     # To be inserted at 800cc51c
     .include "../../Globals.s"
 
-    .set playerdata, 30
     .set player, 29
 
     backup
 
     # fulfill requirements of the static function before branching
-    mr r4, r29             # store player to r4
-    bl Text                # store the address of OSD text to r6
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
     mflr r6
-    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
 
     branchl r12, 0x8000550c
     b Exit

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of Drop.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of Drop.asm
@@ -1,0 +1,24 @@
+    # To be inserted at 8009a2fc
+    .include "../../Globals.s"
+
+    .set player, 31
+
+    backup
+
+    # fulfill requirements of the static function before branching
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
+
+    branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Special OoDrop\nFrame %d"
+    .align 2
+
+Exit:
+    restore
+    cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of Fall.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of Fall.asm
@@ -1,0 +1,26 @@
+    # To be inserted at 800CCAC4
+    # This ASM is injected to "800CCAAC:Fighter_IASACheck_AllAerial" function which is called from some air action states' IASA function.
+    # So this can affect to other action states' IASA besides "Fall".
+    .include "../../Globals.s"
+
+    .set player, 31
+
+    backup
+
+    # fulfill requirements of the static function before branching
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
+
+    branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Special OoFall\nFrame %d"
+    .align 2
+
+Exit:
+    restore
+    cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoAirborne/Special Out of Jump.asm
@@ -1,16 +1,15 @@
     # To be inserted at 800cb354
     .include "../../Globals.s"
 
-    .set playerdata, 31
     .set player, 30
 
     backup
 
     # fulfill requirements of the static function before branching
-    mr r4, r30             # store player to r4
-    bl Text                # store the address of OSD text to r6
+    mr r4, player              # store player to r4
+    bl Text                    # store the address of OSD text to r6
     mflr r6
-    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+    li r10, OSD.ActOoAirborne  # store the OSD kind ID to r10
 
     branchl r12, 0x8000550c
     b Exit

--- a/ASM/training-mode/Onscreen Display/Act OoJump/Aerial Out of DoubleJump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJump/Aerial Out of DoubleJump.asm
@@ -6,8 +6,19 @@
 
     backup
 
-    mr r4, r29  # Branch to Interrupt Check With Interrupt Bool in r3 and player in r4
+    # fulfill requirements of the static function before branching
+    mr r4, r29             # store player to r4
+    bl Text                # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+
     branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Aerial OoDblJump\nFrame %d"
+    .align 2
 
 Exit:
     restore

--- a/ASM/training-mode/Onscreen Display/Act OoJump/Aerial Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJump/Aerial Out of Jump.asm
@@ -6,8 +6,20 @@
 
     backup
 
-    mr r4, r30  # Branch to Interrupt Check With Interrupt Bool in r3 and player in r4
+    # fulfill requirements of the static function before branching
+    mr r4, r30             # store player to r4
+    bl Text                # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+
     branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Aerial OoJump\nFrame %d"
+    .align 2
+
 Exit:
     restore
     cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Act OoJump/Display Act OoJump Frame Count - Static Function.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJump/Display Act OoJump Frame Count - Static Function.asm
@@ -41,7 +41,15 @@ CheckForPreviousActionState:
     beq PreviousStateIsDoubleJump
     cmpwi r3, ASID_JumpAerialB
     beq PreviousStateIsDoubleJump
-    b Exit
+    # Aerial jump state IDs are 0x155, 0x156, 0x157, 0x158, 0x159 for fighters which have multiple jumps (Jigglypuff, Kirby)
+    lwz r4, 0x168(playerdata) # load max_jumps
+    cmpwi r4, 0x2
+    ble Exit
+    cmpwi r3, 0x155 # first aerial jump
+    blt Exit
+    cmpwi r3, 0x159 # last(5th) aerial jump
+    bgt Exit
+    b PreviousStateIsDoubleJump
 
 PreviousStateIsJump:
     lfs f1, 0x150(playerdata)  # get jump_v_initial_velocity
@@ -82,6 +90,12 @@ CheckForDoubleJump:
     cmpwi r3, ASID_JumpAerialF
     beq DoubleJump
     cmpwi r3, ASID_JumpAerialB
+    beq DoubleJump
+    # First aerial jump state ID is 0x155 for fighters which have multiple jumps (Jigglypuff, Kirby)
+    lwz r4, 0x168(playerdata) # load max_jumps
+    cmpwi r4, 0x2
+    ble CheckForAerial
+    cmpwi r3, 0x155 # first aerial jump
     beq DoubleJump
 
 CheckForAerial:

--- a/ASM/training-mode/Onscreen Display/Act OoJump/DoubleJump Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJump/DoubleJump Out of Jump.asm
@@ -6,8 +6,19 @@
 
     backup
 
-    mr r4, r30  # Branch to Interrupt Check With Interrupt Bool in r3 and player in r4
+    # fulfill requirements of the static function before branching
+    mr r4, r30                 # store player to r4
+    bl Text                    # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.Miscellaneous  # store the OSD kind ID to r10 / Originally OSD.ActOoJump is natural, but use other ID to show at the same time as Aerial OoJump for fighters with DoubleJump cancel techniques
+
     branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "DblJump OoJump\nFrame %d"
+    .align 2
 
 Exit:
     restore

--- a/ASM/training-mode/Onscreen Display/Act OoJump/Special Out of DoubleJump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJump/Special Out of DoubleJump.asm
@@ -6,8 +6,19 @@
 
     backup
 
-    mr r4, r29  # Branch to Interrupt Check With Interrupt Bool in r3 and player in r4
+    # fulfill requirements of the static function before branching
+    mr r4, r29             # store player to r4
+    bl Text                # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+
     branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Special OoDblJump\nFrame %d"
+    .align 2
 
 Exit:
     restore

--- a/ASM/training-mode/Onscreen Display/Act OoJump/Special Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJump/Special Out of Jump.asm
@@ -6,8 +6,20 @@
 
     backup
 
-    mr r4, r30  # Branch to Interrupt Check With Interrupt Bool in r3 and player in r4
+    # fulfill requirements of the static function before branching
+    mr r4, r30             # store player to r4
+    bl Text                # store the address of OSD text to r6
+    mflr r6
+    li r10, OSD.ActOoJump  # store the OSD kind ID to r10
+
     branchl r12, 0x8000550c
+    b Exit
+
+Text:
+    blrl
+    .string "Special OoJump\nFrame %d"
+    .align 2
+
 Exit:
     restore
     cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Toggle UI/Load Alt Text When Loaded With L.asm
+++ b/ASM/training-mode/Onscreen Display/Toggle UI/Load Alt Text When Loaded With L.asm
@@ -332,7 +332,7 @@ TextASCIIRight:
     .string "" # DO NOT USE - reserved for custom events
     .string "Act OoLag"
     .string "Crouch Cancel"
-    .string "Act OoJump"
+    .string "Act OoAirborne"
     .string "Jump Cancel Timing"
     .string "Fastfall Timing"
     .string "Frame Advantage"


### PR DESCRIPTION
- Fix a bug of Act OoJump for fighters which have multiple jumps
  ref. https://github.com/AlexanderHarrison/TrainingMode-CommunityEdition/pull/116#issuecomment-2475206424
- Refactoring static function of Act OoJump
- Add "Act Out of **Drop**" and "Act Out of **Fall**"
- For added 2 OSDs above, rename "Act OoJump" to "Act Oo**Airborne**"
  - if "out of airborne" is weird word, please tell me other better word