### PR TITLE
fix a bug raising error on displaying State Name for getting some special moves

### DIFF
--- a/src/lab.c
+++ b/src/lab.c
@@ -477,6 +477,23 @@ void InfoDisplay_Update(GOBJ *menu_gobj, EventOption menu[], GOBJ *fighter, GOBJ
                         int posStart;
                         int nameSize = 0;
                         char *symbol = action->anim_symbol;
+
+                        // extract from the opponent fighter actions if there is no symbol in the fighter action (e.g. getting Yoshi's Neutral-B, Mewtwo's Side-B, Bowser's Side-B, etc.)
+                        if (symbol == NULL) {
+                            // loop through all humans
+                            for (int i = 0; i < 6; i++) {
+                                if (i == fighter_data->ply) { continue; }
+
+                                GOBJ *other_fighter = Fighter_GetGObj(i);
+                                if (other_fighter == 0) { continue; }
+
+                                FighterData *other_fighter_data = other_fighter->userdata;
+                                action = Fighter_GetFtAction(other_fighter_data, fighter_data->action_id);
+                                symbol = action->anim_symbol;
+                                if (symbol != NULL) { break; }
+                            }
+                        }
+
                         for (int i = 0; pos < 50; pos++)
                         {
                             // search for "N_"


### PR DESCRIPTION
I noticed that displaying "State Name" in Training Lab cause a error when getting some special moves.
(Yoshi's neutral B, Bowser's side-B and its pummel and throw, Mewtwo's side-B, DK's F-throw, Kirby's neutral-B (spitting out / copy / copied Yoshi's neutral-B),

![image](https://github.com/user-attachments/assets/2cefd9f4-2b32-4636-b4fd-62df30cf500e)

Maybe it seems that these state name getting some special moves are not in victim's fighter file but in its attacker's fighter file because ditto doesn't cause this error.
I don't know my thought is truly correct, but this PR fixes causing this error anyway.

<details><summary>if appilied this PR</summary>

![GTME01_2024-11-18_14-12-03](https://github.com/user-attachments/assets/8383318f-4bc8-4fde-991a-982938cccac0)
![GTME01_2024-11-18_14-12-43](https://github.com/user-attachments/assets/44c2da7e-7fd2-4e06-88e4-dd8217f987b6)
![GTME01_2024-11-18_14-14-00](https://github.com/user-attachments/assets/611b30bb-75dc-444c-8db8-dc7392d936d1)
![GTME01_2024-11-18_14-14-28](https://github.com/user-attachments/assets/cbf0c632-1696-46d7-9c28-9f8ccf8174fa)
![GTME01_2024-11-18_14-14-44](https://github.com/user-attachments/assets/46f0803f-339f-47af-ae10-7cff69e8717d)
![GTME01_2024-11-18_14-15-30](https://github.com/user-attachments/assets/e451818c-3e9d-4856-acf2-2441c6b841b2)
![GTME01_2024-11-18_14-16-57](https://github.com/user-attachments/assets/72dd2479-3683-45ab-a423-164b5c1ff03b)

</details>

　
Best solution seems to be display ANOTHER state(?) name we can see here in the vanila melee debug mode with Y+Dpad down, but Idk how to look up the state names...
(e.g. `SHOULDERWAIT` for getting DK's f-throw)
![image](https://github.com/user-attachments/assets/3648fc86-8edc-4b45-906e-33a51d95b254)
