### PR TITLE
Enable cursor of event pause menu to move to the top/bottom when cursor is at the bottom/top

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -3256,8 +3256,8 @@ void EventMenu_MenuThink(GOBJ *gobj, EventMenu *currMenu) {
                 cursor = cursor_max;
             }
         }
-        // if no more options, move to the top
-        else {
+        // if no more options, move to the top if not in rapid mode
+        else if (inputs_rapid) {
             // * This implementation assumes that the top option will never be disabled.
             // * Otherwise, we need to search `enabled_option_min_index` and adjust cursor/scroll to the option.
             cursor = cursor_min;
@@ -3298,8 +3298,8 @@ void EventMenu_MenuThink(GOBJ *gobj, EventMenu *currMenu) {
                 cursor = 0;       // cursor is positioned at 0
             }
         }
-        // if no more options, move to the bottom
-        else {
+        // if no more options, move to the bottom if not in rapid mode
+        else if (inputs_rapid) {
             int enabled_option_max_index = -1;
             for (int i = (option_num - 1); i >= 0; i--) {
                 if (currMenu->options[i].disable == 0) {

--- a/src/events.c
+++ b/src/events.c
@@ -3214,7 +3214,7 @@ void EventMenu_MenuThink(GOBJ *gobj, EventMenu *currMenu) {
     u8 pauser = menuData->controller_index;
     // get their  inputs
     HSD_Pad *pad = PadGet(pauser, PADGET_MASTER);
-    int inputs_rapid = Pad_GetRapidHeld(pauser); // pad->rapidFire;
+    int inputs_rapid = pad->rapidFire;
     int inputs_held = pad->held;
     int inputs = inputs_rapid;
     if ((inputs_held & HSD_TRIGGER_R) != 0)


### PR DESCRIPTION
![GTME01_2024-11-30_01-09-57](https://github.com/user-attachments/assets/ced15ee7-2289-4cc0-92de-23994bccef30)
↑ on this screen, input up then ↓
![GTME01_2024-11-30_01-10-05](https://github.com/user-attachments/assets/c9eee804-c8df-46d3-b169-bf26f37fd182)


I wanted this jumping cursor to be suspended for a second not only in rapid mode but also semi rapid mode (holding up/down input), but I couldn't know how to detect it...
