### PR TITLE
Cpu counter action on grab breakout

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -2,7 +2,7 @@
 
 #define TM_VERSSHORT "TM-CE v1.1 dev 2"
 #define TM_VERSLONG "TM Community Edition v1.1 dev 2"
-#define TM_DEBUG 0 // 0 = release (no logging), 1 = OSReport logs, 2 = onscreen logs
+#define TM_DEBUG 2 // 0 = release (no logging), 1 = OSReport logs, 2 = onscreen logs
 #define EVENT_DATASIZE 512
 #define TM_FUNC -(50 * 4)
 #define MENU_MAXOPTION 9

--- a/src/events.h
+++ b/src/events.h
@@ -2,7 +2,7 @@
 
 #define TM_VERSSHORT "TM-CE v1.1 dev 2"
 #define TM_VERSLONG "TM Community Edition v1.1 dev 2"
-#define TM_DEBUG 2 // 0 = release (no logging), 1 = OSReport logs, 2 = onscreen logs
+#define TM_DEBUG 0 // 0 = release (no logging), 1 = OSReport logs, 2 = onscreen logs
 #define EVENT_DATASIZE 512
 #define TM_FUNC -(50 * 4)
 #define MENU_MAXOPTION 9

--- a/src/lab.c
+++ b/src/lab.c
@@ -1988,7 +1988,6 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
     case (CPUSTATE_COUNTER):
     CPULOGIC_COUNTER:
     {
-        TMLOG("In COUNTER state");
         int actionable_this_frame = CPUAction_CheckASID(cpu, ASID_ACTIONABLE);
 
         // check if the CPU has been actionable yet

--- a/src/lab.c
+++ b/src/lab.c
@@ -1231,10 +1231,14 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
     // noact
     cpu_data->cpu.ai = 15;
 
-    if ((cpu_data->TM.state_prev[0] == ASID_CAPTURECUT && cpu_state != ASID_CAPTURECUT) || (cpu_data->TM.state_prev[0] == ASID_CAPTUREJUMP && cpu_state != ASID_CAPTUREJUMP))
+    int last_state = cpu_data->TM.state_prev[0];
+    bool is_cpu_no_longer_in_captur_cut = last_state == ASID_CAPTURECUT && cpu_state != ASID_CAPTURECUT;
+    bool is_cpu_no_longer_in_captur_jump = last_state == ASID_CAPTUREJUMP && cpu_state != ASID_CAPTUREJUMP;
+
+    if((is_cpu_no_longer_in_captur_cut || is_cpu_no_longer_in_captur_jump) && cpu_data->TM.state_frame == 1)
     {
-      cpu_state = CPUSTATE_COUNTER;
-      goto CPULOGIC_COUNTER;
+        eventData->cpu_state = CPUSTATE_COUNTER;
+        goto CPULOGIC_COUNTER;
     }
 
     // if first throw frame, advance hitnum
@@ -2056,10 +2060,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
                 break;
             }
             
-            // This is needed to avoid the cpu going into COUNTER_STATE indefinitly when the counter action is set to NONE
-            cpu_data->TM.state_prev[0] = CPUSTATE_COUNTER;
-
-            if (cpu_data->phys.air_state == 0 || (eventData->cpu_groundstate == 0)) // if am grounded or started grounded
+            if (cpu_data->phys.air_state == 0 || eventData->cpu_groundstate == 0) // if am grounded or started grounded
             {
                 int grndCtr = LabOptions_CPU[OPTCPU_CTRGRND].option_val;
                 action_id = CPUCounterActionsGround[grndCtr];
@@ -2130,6 +2131,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
     if (CPUAction_CheckASID(cpu, ASID_ACTIONABLE) || eventData->cpu_countering) {
         eventData->cpu_countertimer++;
     } else {
+        TMLOG("Test");
         eventData->cpu_countertimer = 0;
     }
 

--- a/src/lab.c
+++ b/src/lab.c
@@ -2052,7 +2052,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
         }
 
         // Additional check for the grab release counter action
-        else if (cpu_data->TM.state_prev[0] == ASID_CAPTURECUT || cpu_data->TM.state_prev[0] == ASID_CAPTUREJUMP)
+        else if (last_state == ASID_CAPTURECUT || last_state == ASID_CAPTUREJUMP)
         {
 
             if (eventData->cpu_countertimer < LabOptions_CPU[OPTCPU_CTRFRAMES].option_val)

--- a/src/lab.c
+++ b/src/lab.c
@@ -2131,7 +2131,6 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
     if (CPUAction_CheckASID(cpu, ASID_ACTIONABLE) || eventData->cpu_countering) {
         eventData->cpu_countertimer++;
     } else {
-        TMLOG("Test");
         eventData->cpu_countertimer = 0;
     }
 


### PR DESCRIPTION
This pull request intends to address [this issue](https://github.com/AlexanderHarrison/TrainingMode-CommunityEdition/issues/156)

I'm not sure about the correctness of the line 2060: 
```C
cpu_data->TM.state_prev[0] = CPUSTATE_COUNTER;
```
I couldn't find a better way to not let the CPU in COUNTERSTATE indefinitely. 
