### PR TITLE
Added the cpu grab release Grounded / Airborn toggle inside the lab

### DIFF
--- a/src/lab.c
+++ b/src/lab.c
@@ -1366,21 +1366,13 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
         {
             eventData->cpu_state = CPUSTATE_RECOVER;
             goto CPULOGIC_RECOVER;
-        }
-
-        if (LabOptions_CPU[OPTCPU_GRABRELEASE].option_val == CPUGRABRELEASE_AIRBORN)
-        {
-            cpu_data->cpu.held |= HSD_BUTTON_X;
-        }
+        } 
 
         switch (LabOptions_CPU[OPTCPU_MASH].option_val)
         {
         case (CPUMASH_NONE):
         {
-            // Fighter_ZeroCPUInputs(cpu_data);
-            cpu_data->input.lstick.X = 0;
-            cpu_data->input.lstick.Y = 0;
-
+            Fighter_ZeroCPUInputs(cpu_data);
             break;
         }
         case (CPUMASH_MED):
@@ -1393,7 +1385,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
                 cpu_data->input.lstick.Y = 0;
 
                 // input
-                cpu_data->cpu.held |= PAD_BUTTON_A;
+                cpu_data->cpu.held = PAD_BUTTON_A;
                 cpu_data->cpu.lstickX = 127;
             }
             break;
@@ -1408,7 +1400,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
                 cpu_data->input.lstick.Y = 0;
 
                 // input
-                cpu_data->cpu.held |= PAD_BUTTON_A;
+                cpu_data->cpu.held = PAD_BUTTON_A;
                 cpu_data->cpu.lstickX = 127;
             }
             break;
@@ -1421,10 +1413,15 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
             cpu_data->input.lstick.Y = 0;
 
             // input
-            cpu_data->cpu.held |= PAD_BUTTON_A;
+            cpu_data->cpu.held = PAD_BUTTON_A;
             cpu_data->cpu.lstickX = 127;
             break;
         }
+        }
+
+        if (LabOptions_CPU[OPTCPU_GRABRELEASE].option_val == CPUGRABRELEASE_AIRBORN)
+        {
+            cpu_data->cpu.held |= HSD_BUTTON_X;
         }
 
         break;

--- a/src/lab.c
+++ b/src/lab.c
@@ -1368,23 +1368,19 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
             goto CPULOGIC_RECOVER;
         }
 
-        // The default held button is PAD_BUTTON_A
-        int input = PAD_BUTTON_A;
-
         if (LabOptions_CPU[OPTCPU_GRABRELEASE].option_val == CPUGRABRELEASE_AIRBORN)
         {
-            input =  HSD_BUTTON_X;
+            cpu_data->cpu.held |= HSD_BUTTON_X;
         }
 
         switch (LabOptions_CPU[OPTCPU_MASH].option_val)
         {
         case (CPUMASH_NONE):
         {
-            Fighter_ZeroCPUInputs(cpu_data);
-            if (LabOptions_CPU[OPTCPU_GRABRELEASE].option_val == CPUGRABRELEASE_AIRBORN)    
-            {
-                cpu_data->cpu.held = HSD_BUTTON_X;
-            }
+            // Fighter_ZeroCPUInputs(cpu_data);
+            cpu_data->input.lstick.X = 0;
+            cpu_data->input.lstick.Y = 0;
+
             break;
         }
         case (CPUMASH_MED):
@@ -1397,7 +1393,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
                 cpu_data->input.lstick.Y = 0;
 
                 // input
-                cpu_data->cpu.held = input;
+                cpu_data->cpu.held |= PAD_BUTTON_A;
                 cpu_data->cpu.lstickX = 127;
             }
             break;
@@ -1412,7 +1408,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
                 cpu_data->input.lstick.Y = 0;
 
                 // input
-                cpu_data->cpu.held = input;
+                cpu_data->cpu.held |= PAD_BUTTON_A;
                 cpu_data->cpu.lstickX = 127;
             }
             break;
@@ -1425,7 +1421,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
             cpu_data->input.lstick.Y = 0;
 
             // input
-            cpu_data->cpu.held = input;
+            cpu_data->cpu.held |= PAD_BUTTON_A;
             cpu_data->cpu.lstickX = 127;
             break;
         }

--- a/src/lab.c
+++ b/src/lab.c
@@ -1368,12 +1368,24 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
             goto CPULOGIC_RECOVER;
         }
 
+        // The default held button is PAD_BUTTON_A
+        int input = PAD_BUTTON_A;
+
+        if (LabOptions_CPU[OPTCPU_GRABRELEASE].option_val == CPUGRABRELEASE_AIRBORN)
+        {
+            input =  HSD_BUTTON_X;
+        }
+
         switch (LabOptions_CPU[OPTCPU_MASH].option_val)
         {
         case (CPUMASH_NONE):
         {
             Fighter_ZeroCPUInputs(cpu_data);
-            break;
+            if (LabOptions_CPU[OPTCPU_GRABRELEASE].option_val == CPUGRABRELEASE_AIRBORN)    
+            {
+                cpu_data->input.held = HSD_BUTTON_X;
+            }
+            ;
         }
         case (CPUMASH_MED):
         {
@@ -1385,7 +1397,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
                 cpu_data->input.lstick.Y = 0;
 
                 // input
-                cpu_data->cpu.held = PAD_BUTTON_A;
+                cpu_data->cpu.held = input;
                 cpu_data->cpu.lstickX = 127;
             }
             break;
@@ -1400,7 +1412,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
                 cpu_data->input.lstick.Y = 0;
 
                 // input
-                cpu_data->cpu.held = PAD_BUTTON_A;
+                cpu_data->cpu.held = input;
                 cpu_data->cpu.lstickX = 127;
             }
             break;
@@ -1413,7 +1425,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
             cpu_data->input.lstick.Y = 0;
 
             // input
-            cpu_data->cpu.held = PAD_BUTTON_A;
+            cpu_data->cpu.held = input;
             cpu_data->cpu.lstickX = 127;
             break;
         }

--- a/src/lab.c
+++ b/src/lab.c
@@ -1366,7 +1366,7 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
         {
             eventData->cpu_state = CPUSTATE_RECOVER;
             goto CPULOGIC_RECOVER;
-        } 
+        }
 
         switch (LabOptions_CPU[OPTCPU_MASH].option_val)
         {

--- a/src/lab.c
+++ b/src/lab.c
@@ -1383,9 +1383,9 @@ void CPUThink(GOBJ *event, GOBJ *hmn, GOBJ *cpu)
             Fighter_ZeroCPUInputs(cpu_data);
             if (LabOptions_CPU[OPTCPU_GRABRELEASE].option_val == CPUGRABRELEASE_AIRBORN)    
             {
-                cpu_data->input.held = HSD_BUTTON_X;
+                cpu_data->cpu.held = HSD_BUTTON_X;
             }
-            ;
+            break;
         }
         case (CPUMASH_MED):
         {

--- a/src/lab.h
+++ b/src/lab.h
@@ -1189,6 +1189,14 @@ enum cpu_mash
     CPUMASH_COUNT
 };
 
+enum cpu_grab_release
+{
+    CPUGRABRELEASE_GROUNDED,
+    CPUGRABRELEASE_AIRBORN,
+
+    CPUGRABRELEASE_COUNT
+};
+
 enum cpu_inf_shield {
     CPUINFSHIELD_OFF,
     CPUINFSHIELD_UNTIL_HIT,
@@ -1248,6 +1256,7 @@ enum cpu_option
     OPTCPU_SHIELDDIR,
     OPTCPU_INTANG,
     OPTCPU_MASH,
+    OPTCPU_GRABRELEASE,
     OPTCPU_BEHAVE,
     OPTCPU_CTRGRND,
     OPTCPU_CTRAIR,
@@ -1270,6 +1279,7 @@ static char *LabValues_SDIDir[] = {"Random", "Away", "Towards", "Up", "Down", "L
 static char *LabValues_Tech[] = {"Random", "Neutral", "Away", "Towards", "None"};
 static char *LabValues_Getup[] = {"Random", "Stand", "Away", "Towards", "Attack"};
 static char *LabValues_GrabEscape[] = {"None", "Medium", "High", "Perfect"};
+static char *LabValues_GrabRelease[] = {"Grounded", "Airborn"};
 static char *LabValues_LockCPUPercent[] = {"Off", "On"};
 static char *LabValues_CPUControlledBy[] = {"None", "Port 1", "Port 2", "Port 3", "Port 4"};
 
@@ -1374,6 +1384,14 @@ static EventOption LabOptions_CPU[OPTCPU_COUNT] = {
         .option_name = "Grab Escape",
         .desc = "Adjust how the CPU will attempt to escape\ngrabs.",
         .option_values = LabValues_GrabEscape,
+    },
+    {
+        .option_kind = OPTKIND_STRING,
+        .value_num = sizeof(LabValues_GrabRelease) / 4,
+        .option_val = CPUGRABRELEASE_GROUNDED,
+        .option_name = "Grab Release",
+        .desc = "Adjust how the CPU will escape grabs.",
+        .option_values = LabValues_GrabRelease,
     },
     {
         .option_kind = OPTKIND_STRING,


### PR DESCRIPTION
In this pull request, I added a toggle to set the cpu grab release behavior.

It looks like this : 

![image](https://github.com/user-attachments/assets/cedf5ca2-c8ac-4f60-b1b7-d54fda678e09)

with Grounded / Airborn as options.

If Grounded is set, nothing changes since that's the CPU was by default.
If Airborn is set, the cpu will hold the ``HSD_BUTTON_X`` corresponding to the X button.

I tried my best to test if it changed the mashing inputs for the ``CPUMASH_NONE``option (with DK cargo throw) and it seemed to only add the jump input once. This would probably need more testing ...