### PR TITLE
fix missed l-cancel overlay edge case

### DIFF
--- a/src/lab.c
+++ b/src/lab.c
@@ -882,8 +882,8 @@ static int CheckOverlay(GOBJ *character, OverlayGroup overlay)
             if (state < ASID_LANDINGAIRN || ASID_LANDINGAIRLW < state)
                 return false;
 
-            int frames_from_first_l = data->TM.state_frame + 7;
-            return data->input.timer_trigger_any_ignore_hitlag > frames_from_first_l;
+            int frames_from_first_possible_l = data->TM.state_frame + 7;
+            return (data->input.timer_trigger_any_ignore_hitlag + 1) > frames_from_first_possible_l;
         }
 
         case (OVERLAY_CAN_FASTFALL):


### PR DESCRIPTION
There's an issue where the "Missed L-Cancel" color overlay doesn't show in the Training Lab if the L-Cancel was input one frame too early (i.e. 8 frames before landing). 

The issue is caused by an "off-by-one" mistake, and I'm guessing it's because `data->input.timer_trigger_any_ignore_hitlag` uses 0-based indexing instead of 1 (as in, if an l-cancel is input on a given frame, the next frame will have `data->input.timer_trigger_any_ignore_hitlag = 0`, not `1`) which is slightly confusing. The fix is to just account for that by adding 1.

---

Example with red "Missed L-Cancel" overlay.

Before:

https://github.com/user-attachments/assets/9295f77b-308d-4fd3-9c7b-7b40f8f6f6cb

After:

https://github.com/user-attachments/assets/cc708f88-9a52-4d94-8119-3104ae45ea36

