### PR TITLE
More portable, shellcheck'd build_linux.sh

### DIFF
--- a/TM-CE/build_linux.sh
+++ b/TM-CE/build_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 XDELTA_PATCH_PATH="$SCRIPT_DIR/patch.xdelta"
@@ -14,18 +14,18 @@ else
     exit 1
 fi
 
-if [[ -z ${1} ]]; then 
+if [[ -z "${1}" ]]; then
     echo "ERROR: ISO was not passed"
     exit 1
 fi
 
-if [[ ! -f ${1} ]]; then 
+if [[ ! -f "${1}" ]]; then
     echo "ERROR: ISO '${1}' is not a valid file"
     exit 1
 fi
 
-xdelta3 -f -d -s ${1} ${XDELTA_PATCH_PATH} TM-CE.iso
-if [[ ! $? -eq 0 ]]; then 
+${XDELTA_CMD} -f -d -s "${1}" "${XDELTA_PATCH_PATH}" TM-CE.iso
+if ! ${XDELTA_CMD} -f -d -s "${1}" "${XDELTA_PATCH_PATH}" TM-CE.iso; then 
     echo "ERROR: The ISO '${1}' is not a valid v1.02 NTSC melee iso"
     exit 1
 fi

--- a/TM-CE/build_linux.sh
+++ b/TM-CE/build_linux.sh
@@ -24,7 +24,6 @@ if [[ ! -f "${1}" ]]; then
     exit 1
 fi
 
-${XDELTA_CMD} -f -d -s "${1}" "${XDELTA_PATCH_PATH}" TM-CE.iso
 if ! ${XDELTA_CMD} -f -d -s "${1}" "${XDELTA_PATCH_PATH}" TM-CE.iso; then 
     echo "ERROR: The ISO '${1}' is not a valid v1.02 NTSC melee iso"
     exit 1


### PR DESCRIPTION
`build_linux.sh` failed for me when I tried it (NixOS).

I debugged it myself to get it working:

- The shebang isn't as portable as it could be (NixOS doesn't have `/bin/bash`. `/usr/bin/env` is more portable).
- The ISO path wasn't quoted, and mine had spaces in it.

I also ran it through `shellcheck` (installed via `nix-shell -p shellcheck`) and fixed the things it suggested as well.