### PR TITLE
Add very low lasers to powershield event.

### DIFF
--- a/src/powershield.c
+++ b/src/powershield.c
@@ -19,13 +19,14 @@ enum fire_speed {
 
 enum laser_height {
     LASER_HEIGHT_RANDOM,
+    LASER_HEIGHT_VERY_LOW,
     LASER_HEIGHT_LOW,
     LASER_HEIGHT_MID,
     LASER_HEIGHT_HIGH,
 };
 
 static char *Options_FireSpeed[] = { "Random", "Slow", "Medium", "Fast" };
-static char *Options_LaserHeight[] = { "Random", "Low", "Mid", "High" };
+static char *Options_LaserHeight[] = { "Random", "Very Low", "Low", "Mid", "High" };
 static char *Options_Direction[] = { "Right", "Left" };
 
 static EventOption Options_Main[] = {
@@ -126,6 +127,9 @@ void Event_Think(GOBJ *menu) {
         if (delay_option == LASER_HEIGHT_RANDOM) {
             falco_shoot_delay = HSD_Randi(4) + 2;
             falco_fastfall_delay = 1;
+        } else if (delay_option == LASER_HEIGHT_VERY_LOW) {
+            falco_shoot_delay = 11;
+            falco_fastfall_delay = 8;
         } else if (delay_option == LASER_HEIGHT_LOW) {
             falco_shoot_delay = 5;
             falco_fastfall_delay = 1;


### PR DESCRIPTION
This adds very low lasers to the powershield event.

![image](https://github.com/user-attachments/assets/0fdd6149-d0bd-44d1-9606-a6b4f1d70c31)

Very low lasers have higher potential to touch your foot hitbox while dashing away, and dash away powershield is often chosen as a powershield option because it increases the frame window for powershield in most cases.

I'm not sure if this is worth merging, I just added this so I can test some personal ideas around option select dashback powershield and master the dashback timing such that I only attempt powershield immediately after dashing back (before my foot hitbox extends too far).

P.S. Before merging, the "random laser height" option doesn't include these lasers-- if you want I can add those in too, but the way the "random" option is set up right now isn't really compatible since these are frame perfect inputs that can't be produced by the equation in there right now. Wasn't sure how to add without clobbering your changes.