### PR TITLE
improve missed l-cancel overlay

### DIFF
--- a/src/lab.c
+++ b/src/lab.c
@@ -56,6 +56,8 @@ const int LOCKOUT_DURATION = 30;
 static float cpu_locked_percent = 0;
 static float hmn_locked_percent = 0;
 
+static bool was_missed_lcancel = false;
+
 // Menu Callbacks
 
 void Lab_AddCustomOSD(GOBJ *menu_gobj) {
@@ -1027,8 +1029,10 @@ static int CheckOverlay(GOBJ *character, OverlayGroup overlay)
             if (state < ASID_LANDINGAIRN || ASID_LANDINGAIRLW < state)
                 return false;
 
-            int frames_from_first_possible_l = data->TM.state_frame + 7;
-            return data->input.timer_trigger_any_ignore_hitlag >= frames_from_first_possible_l;
+            if (data->TM.state_frame == 0) {
+                was_missed_lcancel = data->input.timer_trigger_any_ignore_hitlag >= 7;
+            }
+            return was_missed_lcancel;
         }
 
         case (OVERLAY_CAN_FASTFALL):

--- a/src/lab.c
+++ b/src/lab.c
@@ -56,7 +56,7 @@ const int LOCKOUT_DURATION = 30;
 static float cpu_locked_percent = 0;
 static float hmn_locked_percent = 0;
 
-static bool *did_player_miss_lcancel[] = {false, false};
+static bool did_player_miss_lcancel[2] = {false, false};
 
 // Menu Callbacks
 

--- a/src/lab.c
+++ b/src/lab.c
@@ -56,7 +56,7 @@ const int LOCKOUT_DURATION = 30;
 static float cpu_locked_percent = 0;
 static float hmn_locked_percent = 0;
 
-static bool was_missed_lcancel = false;
+static bool *did_player_miss_lcancel[] = {false, false};
 
 // Menu Callbacks
 
@@ -1030,9 +1030,9 @@ static int CheckOverlay(GOBJ *character, OverlayGroup overlay)
                 return false;
 
             if (data->TM.state_frame == 0) {
-                was_missed_lcancel = data->input.timer_trigger_any_ignore_hitlag >= 7;
+                did_player_miss_lcancel[data->ply] = data->input.timer_trigger_any_ignore_hitlag >= 7;
             }
-            return was_missed_lcancel;
+            return did_player_miss_lcancel[data->ply];
         }
 
         case (OVERLAY_CAN_FASTFALL):


### PR DESCRIPTION
The problem with the current missed L-cancel overlay is that it disappears when an L is input during the landing animation. The issue is most noticeable when an L is input one frame late because the overlay is only shown for one frame before disappearing.

The issue happens because the overlay code checks every frame of the landing animation to see if an L was input on any frame since 7 before landing, which incorrectly includes the landing animation frames. 

Here's an example, where the Missed L-Cancel overlay disappears after inputting an L during the landing animation:

https://github.com/user-attachments/assets/00d59c1d-6d4b-4115-90aa-2660e45caf43

---

The fix in this PR is to check if an L-Cancel was missed or not only on the initial aerial landing frame, and store the result in a bool, and have each subsequent frame of the landing re-use the bool result.

https://github.com/user-attachments/assets/e9fb6e79-b32b-433a-8360-0076129b391d