### PR TITLE
add custom fire speed bounds and dpad support to powershield event

### DIFF
--- a/src/powershield.c
+++ b/src/powershield.c
@@ -1,11 +1,20 @@
 #include "../MexTK/mex.h"
 #include "events.h"
 
+#define CPU_LEFT_STAGE_POS_X 70.f
+#define CPU_LEFT_DIRECTION -1.f
+
 void Exit(int value);
+void ChangeFireSpeedOption(GOBJ *event_menu, int value);
 void ChangeDirection(GOBJ *event_menu, int value);
+void ChangeRandomFireDelayMin(GOBJ *event_menu, int value);
+void ChangeRandomFireDelayMax(GOBJ *event_menu, int value);
+int get_random_laser_delay();
 
 enum menu_options {
     OPT_FIRE_SPEED,
+    OPT_FIRE_DELAY_RANDOM_MIN,
+    OPT_FIRE_DELAY_RANDOM_MAX,
     OPT_LASER_HEIGHT,
     OPT_DIRECTION,
 };
@@ -25,6 +34,11 @@ enum laser_height {
     LASER_HEIGHT_HIGH,
 };
 
+enum falco_direction {
+    DIRECTION_RIGHT,
+    DIRECTION_LEFT,
+};
+
 static char *Options_FireSpeed[] = { "Random", "Slow", "Medium", "Fast" };
 static char *Options_LaserHeight[] = { "Random", "Very Low", "Low", "Mid", "High" };
 static char *Options_Direction[] = { "Right", "Left" };
@@ -36,6 +50,27 @@ static EventOption Options_Main[] = {
         .option_name = "Fire Speed",
         .desc = "Change the rate of fire.",
         .option_values = Options_FireSpeed,
+        .onOptionChange = ChangeFireSpeedOption,
+    },
+    {
+        .option_kind = OPTKIND_INT,
+        .value_num = 61,
+        .option_val = 0,
+        .option_name = "Min Fire Delay",
+        .desc = "Adjust the minimum number of frames between lasers",
+        .option_values = "%d",
+        .onOptionChange = ChangeRandomFireDelayMin,
+        .disable = false,
+    },
+    {
+        .option_kind = OPTKIND_INT,
+        .value_num = 61,
+        .option_val = 20,
+        .option_name = "Max Fire Delay",
+        .desc = "Adjust the maximum number of frames between lasers",
+        .option_values = "%d",
+        .onOptionChange = ChangeRandomFireDelayMax,
+        .disable = false,
     },
     {
         .option_kind = OPTKIND_STRING,
@@ -78,7 +113,19 @@ void Event_Think(GOBJ *menu) {
 
     Fighter_ZeroCPUInputs(falco_data);
     falco_data->flags.no_reaction_always = true;
+    falco_data->grab.vuln = 0x1FF;
     player_data->shield.health = 60;
+
+    int new_direction = -1;
+    if (player_data->input.down & HSD_BUTTON_DPAD_LEFT) {
+        new_direction = DIRECTION_RIGHT;
+    } else if (player_data->input.down & HSD_BUTTON_DPAD_RIGHT) {
+        new_direction = DIRECTION_LEFT;
+    }
+    if (new_direction != -1) {
+        Options_Main[OPT_DIRECTION].option_val = new_direction;
+        ChangeDirection(Options_Main, new_direction);
+    }
 
     int state = falco_data->state_id;
     int state_frame = falco_data->TM.state_frame;
@@ -103,7 +150,7 @@ void Event_Think(GOBJ *menu) {
         int delay_option = Options_Main[OPT_FIRE_SPEED].option_val;
 
         if (delay_option == FIRE_SPEED_RANDOM)
-            falco_wait_delay = HSD_Randi(20);
+            falco_wait_delay = get_random_laser_delay();
         else if (delay_option == FIRE_SPEED_SLOW)
             falco_wait_delay = 20;
         else if (delay_option == FIRE_SPEED_MEDIUM)
@@ -161,12 +208,50 @@ void Exit(int value) {
     Match_EndVS();
 }
 
+void ChangeFireSpeedOption(GOBJ *event_menu, int value) {
+    bool disable_random_bounds = value != FIRE_SPEED_RANDOM;
+    Options_Main[OPT_FIRE_DELAY_RANDOM_MIN].disable = disable_random_bounds;
+    Options_Main[OPT_FIRE_DELAY_RANDOM_MAX].disable = disable_random_bounds;
+}
+
 void ChangeDirection(GOBJ *event_menu, int value) {
     GOBJ *falco = Fighter_GetGObj(1);
     FighterData *falco_data = falco->userdata;
 
-    falco_data->facing_direction *= -1.f;
-    falco_data->phys.pos.X *= -1.f;
+    if (value == DIRECTION_LEFT) {
+        falco_data->facing_direction = CPU_LEFT_DIRECTION;
+        falco_data->phys.pos.X = CPU_LEFT_STAGE_POS_X;
+    } else {
+        falco_data->facing_direction = -CPU_LEFT_DIRECTION;
+        falco_data->phys.pos.X = -CPU_LEFT_STAGE_POS_X;    
+    }
+}
+
+void ChangeRandomFireDelayMin(GOBJ *event_menu, int value) {
+    int random_fire_delay_min = Options_Main[OPT_FIRE_DELAY_RANDOM_MIN].option_val;
+    int random_fire_delay_max = Options_Main[OPT_FIRE_DELAY_RANDOM_MAX].option_val;
+
+    // Ensure the min is never greater than the max
+    if (random_fire_delay_min > random_fire_delay_max) {
+        Options_Main[OPT_FIRE_DELAY_RANDOM_MAX].option_val = random_fire_delay_min;
+    }
+}
+
+void ChangeRandomFireDelayMax(GOBJ *event_menu, int value) {
+    int random_fire_delay_min = Options_Main[OPT_FIRE_DELAY_RANDOM_MIN].option_val;
+    int random_fire_delay_max = Options_Main[OPT_FIRE_DELAY_RANDOM_MAX].option_val;
+
+    // Ensure the max is never less than the min
+    if (random_fire_delay_max < random_fire_delay_min) {
+        Options_Main[OPT_FIRE_DELAY_RANDOM_MIN].option_val = random_fire_delay_max;
+    }
+}
+
+int get_random_laser_delay() {
+    int random_fire_delay_min = Options_Main[OPT_FIRE_DELAY_RANDOM_MIN].option_val;
+    int random_fire_delay_max = Options_Main[OPT_FIRE_DELAY_RANDOM_MAX].option_val;
+
+    return HSD_Randi(random_fire_delay_max - random_fire_delay_min) + random_fire_delay_min;
 }
 
 EventMenu *Event_Menu = &Menu_Main;


### PR DESCRIPTION
Make three updates to the powershield event:

1. Allow custom min & max bounds for random laser fire speed (ranging from 0 to 60 frames)
2. Add DPAD left & right support to move the falco direction
3. Make falco ungrabbable

----

The min and max fire speed options are only enabled when fire type is "Random":

| Random (enabled) | Other (disabled) |
| -- | -- |
| ![ps__bounds-enabled](https://github.com/user-attachments/assets/5aed1394-46a6-40ff-a2d4-6e0409f0448f) | ![ps__bounds-disabled](https://github.com/user-attachments/assets/917bc709-365b-475f-9da2-7ef52d2392ae) |

And for UX, if changing the min bound so that it exceeds the max, the max will also change so that the min is never greater than the max (i.e. `maxBound = maxOf(minBound, maxBound`) (and vice versa).  

https://github.com/user-attachments/assets/7130343f-91c4-4bda-8e74-bf38299a3d20

----

Pressing LEFT DPAD moves the falco to the left side of the stage, with facing direction right (and vice versa for RIGHT DPAD). 

Also added fixed values for stage position because sometimes the falco will not fully move to the given X position, but instead move somewhere closer to center stage. (Maybe this has something to do with the X position change happening during landing lag?). Having a fixed X position resets the falco out of this bad state.

https://github.com/user-attachments/assets/b1b3c3f4-46eb-4915-b7de-51c82267de62