### PR TITLE
Remove unfreeze code from event exits

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -1173,8 +1173,6 @@ void EventInit(int page, int eventID, MatchInit *matchData)
 
     // Determine the Stage
     matchData->stage = event->isSelectStage ? preload->queued.stage : eventMatchData->stage;
-
-    return;
 };
 
 void EventLoad()
@@ -1241,8 +1239,6 @@ void EventLoad()
     // Store update function
     HSD_Update *update = stc_hsd_update;
     update->onFrame = EventUpdate;
-
-    return;
 };
 
 void EventUpdate()
@@ -1273,8 +1269,6 @@ void EventUpdate()
     }
     else
         Develop_UpdateMatchHotkeys();
-
-    return;
 }
 
 //////////////////////
@@ -1329,8 +1323,6 @@ void TM_CreateConsole()
         DevelopText_HideBG(text);
         DevelopText_HideText(text);
     }
-
-    return;
 }
 
 void OnFileLoad(HSD_Archive *archive) // this function is run right after TmDt is loaded into memory on boot
@@ -1341,27 +1333,21 @@ void OnFileLoad(HSD_Archive *archive) // this function is run right after TmDt i
     // store pointer to static variables
     *event_vars_ptr = &stc_event_vars;
     event_vars = *event_vars_ptr;
-
-    return;
 }
 
 void OnSceneChange()
 {
     // Hook exists at 801a4c94
-
     TM_CreateWatermark();
 
 #if TM_DEBUG == 2
     TM_CreateConsole();
 #endif
-
-    return;
 };
 
 void OnBoot()
 {
     // OSReport("hi this is boot\n");
-    return;
 };
 
 void OnStartMelee()
@@ -1369,8 +1355,6 @@ void OnStartMelee()
 
     Message_Init();
     Tip_Init();
-
-    return;
 }
 
 ///////////////////////////////
@@ -2105,8 +2089,6 @@ void Update_Savestates()
             }
         }
     }
-
-    return;
 }
 int GOBJToID(GOBJ *gobj)
 {
@@ -2212,7 +2194,6 @@ JOBJ *IDToBone(FighterData *fighter_data, int id)
 void Event_IncTimer(GOBJ *gobj)
 {
     stc_event_vars.game_timer++;
-    return;
 }
 void TM_CreateWatermark()
 {
@@ -2245,8 +2226,6 @@ void TM_CreateWatermark()
     Text_SetColor(text, shadow3, &shadow_color);
 
     Text_AddSubtext(text, 0, 0, TM_VersShort);
-
-    return;
 }
 void Hazards_Disable()
 {
@@ -2350,8 +2329,6 @@ void Message_Init()
 
     // store gobj pointer
     stc_msgmgr = mgr_gobj;
-
-    return;
 }
 GOBJ *Message_Display(int msg_kind, int queue_num, int msg_color, char *format, ...)
 {
@@ -2670,8 +2647,6 @@ void Message_Destroy(GOBJ **msg_queue, int msg_num)
                 this_msg_data->prev_index = i + 1; // prev position
         }
     }
-
-    return;
 }
 void Message_Add(GOBJ *msg_gobj, int queue_num)
 {
@@ -2741,16 +2716,11 @@ void Message_Add(GOBJ *msg_gobj, int queue_num)
     // set prev pos to -1 (slides in)
     msg_data->prev_index = -1;
     msg_data->orig_index = 0;
-
-    return;
 }
 void Message_CObjThink(GOBJ *gobj)
 {
-
     if (Pause_CheckStatus(1) != 2)
         CObjThink_Common(gobj);
-
-    return;
 }
 
 float BezierBlend(float t)
@@ -2767,8 +2737,6 @@ void Tip_Init()
     // create tipmgr gobj
     GOBJ *tipmgr_gobj = GObj_Create(0, 7, 0);
     GObj_AddProc(tipmgr_gobj, Tip_Think, 18);
-
-    return;
 }
 void Tip_Think(GOBJ *gobj)
 {
@@ -2835,8 +2803,6 @@ void Tip_Think(GOBJ *gobj)
         }
         }
     }
-
-    return;
 }
 int Tip_Display(int lifetime, char *fmt, ...)
 {
@@ -2976,8 +2942,6 @@ void Tip_Destroy()
 
         stc_tipmgr.state = 2; // enter wait
     }
-
-    return;
 }
 
 ////////////////////////////
@@ -3185,23 +3149,18 @@ void EventMenu_Update(GOBJ *gobj)
         Match_ShowHUD();
         Match_AdjustSoundOnPause(0);
     }
-
-    return;
 }
 
 void EventMenu_MenuGX(GOBJ *gobj, int pass)
 {
     if (stc_event_vars.hide_menu == 0)
         GXLink_Common(gobj, pass);
-    return;
 }
 
 void EventMenu_TextGX(GOBJ *gobj, int pass)
 {
-
     if (stc_event_vars.hide_menu == 0)
         Text_GX(gobj, pass);
-    return;
 }
 
 void EventMenu_MenuThink(GOBJ *gobj, EventMenu *currMenu) {
@@ -3489,8 +3448,6 @@ void EventMenu_MenuThink(GOBJ *gobj, EventMenu *currMenu) {
         // update menu
         EventMenu_UpdateText(gobj, currMenu);
     }
-
-    return;
 }
 
 void EventMenu_PopupThink(GOBJ *gobj, EventMenu *currMenu)
@@ -3636,8 +3593,6 @@ void EventMenu_PopupThink(GOBJ *gobj, EventMenu *currMenu)
         // update menu
         EventMenu_UpdatePopupText(gobj, currOption);
     }
-
-    return;
 }
 
 void EventMenu_CreateModel(GOBJ *gobj, EventMenu *menu)
@@ -3771,8 +3726,6 @@ void EventMenu_CreateModel(GOBJ *gobj, EventMenu *menu)
         menuData->scroll_bot = 0;
         menuData->scroll_top = 0;
     }
-
-    return;
 }
 
 void EventMenu_CreateText(GOBJ *gobj, EventMenu *menu)
@@ -3891,8 +3844,6 @@ void EventMenu_CreateText(GOBJ *gobj, EventMenu *menu)
         float optionY = MENU_OPTIONVALYPOS + (i * MENU_TEXTYOFFSET);
         subtext = Text_AddSubtext(text, optionX, optionY, &nullString);
     }
-
-    return;
 }
 
 void EventMenu_UpdateText(GOBJ *gobj, EventMenu *menu)
@@ -4108,8 +4059,6 @@ void EventMenu_UpdateText(GOBJ *gobj, EventMenu *menu)
 
     // update jobj
     JOBJ_SetMtxDirtySub(gobj->hsd_object);
-
-    return;
 }
 
 void EventMenu_DestroyMenu(GOBJ *gobj)
@@ -4152,8 +4101,6 @@ void EventMenu_DestroyMenu(GOBJ *gobj)
     // remove jobj
     GObj_FreeObject(gobj);
     //GObj_DestroyGXLink(gobj);
-
-    return;
 }
 
 void EventMenu_CreatePopupModel(GOBJ *gobj, EventMenu *menu)
@@ -4233,8 +4180,6 @@ void EventMenu_CreatePopupModel(GOBJ *gobj, EventMenu *menu)
     jobj_highlight->dobj->next->mobj->mat->diffuse = highlight;
 
     menuData->highlight_popup = jobj_highlight;
-
-    return;
 }
 
 void EventMenu_CreatePopupText(GOBJ *gobj, EventMenu *menu)
@@ -4275,8 +4220,6 @@ void EventMenu_CreatePopupText(GOBJ *gobj, EventMenu *menu)
         float optionY = baseYPos + (i * POPUP_TEXTYOFFSET);
         subtext = Text_AddSubtext(text, optionX, optionY, &nullString);
     }
-
-    return;
 }
 
 void EventMenu_UpdatePopupText(GOBJ *gobj, EventOption *option)
@@ -4321,8 +4264,6 @@ void EventMenu_UpdatePopupText(GOBJ *gobj, EventOption *option)
     JOBJ *highlight_joint = menuData->highlight_popup;
     highlight_joint->trans.Y = cursor * POPUPHIGHLIGHT_YOFFSET;
     JOBJ_SetMtxDirtySub(highlight_joint);
-
-    return;
 }
 
 void EventMenu_DestroyPopup(GOBJ *gobj)

--- a/src/lab.c
+++ b/src/lab.c
@@ -210,8 +210,6 @@ void Lab_ChangePlayerPercent(GOBJ *menu_gobj, int value)
         hmn_locked_percent = fighter_data->dmg.percent;
 
     Fighter_SetHUDDamage(0, value);
-
-    return;
 }
 void Lab_ChangePlayerLockPercent(GOBJ *menu_gobj, int value)
 {
@@ -220,8 +218,6 @@ void Lab_ChangePlayerLockPercent(GOBJ *menu_gobj, int value)
 
     if (value)
         hmn_locked_percent = fighter_data->dmg.percent;
-
-    return;
 }
 
 void Lab_StartMoveCPU(GOBJ *menu_gobj) {
@@ -261,8 +257,6 @@ void Lab_ChangeFrameAdvance(GOBJ *menu_gobj, int value)
     // apply colanim
     else
         LabOptions_General[OPTGEN_FRAMEBTN].disable = 0;
-
-    return;
 }
 
 void Lab_ChangeFrameAdvanceButton(GOBJ *menu_gobj, int value) {
@@ -279,8 +273,6 @@ void Lab_ChangeRandom(GOBJ *menu_gobj, int value)
     // apply colanim
     else
         LabOptions_General[OPTGEN_FRAMEBTN].disable = 0;
-
-    return;
 }
 void Lab_ChangeCPUPercent(GOBJ *menu_gobj, int value)
 {
@@ -292,8 +284,6 @@ void Lab_ChangeCPUPercent(GOBJ *menu_gobj, int value)
 
     if (LabOptions_CPU[OPTCPU_LOCKPCNT].option_val)
         cpu_locked_percent = fighter_data->dmg.percent;
-
-    return;
 }
 void Lab_ChangeCPULockPercent(GOBJ *menu_gobj, int value)
 {
@@ -303,8 +293,6 @@ void Lab_ChangeCPULockPercent(GOBJ *menu_gobj, int value)
 
     if (value)
         cpu_locked_percent = fighter_data->dmg.percent;
-
-    return;
 }
 void Lab_ChangeTech(GOBJ *menu_gobj, int value)
 {
@@ -401,8 +389,6 @@ void Lab_ChangeCPUIntang(GOBJ *menu_gobj, int value)
         Fighter_ColAnim_Remove(fighter_data, INTANG_COLANIM);
     else
         Fighter_ColAnim_Apply(fighter_data, INTANG_COLANIM, 0);
-
-    return;
 }
 
 void Lab_ChangeModelDisplay(GOBJ *menu_gobj, int value)
@@ -431,8 +417,6 @@ void Lab_ChangeModelDisplay(GOBJ *menu_gobj, int value)
     bool hide_misc = hide_stage || hide_chars;
 
     stc_matchcam->hide_effects = hide_misc;
-
-    return;
 }
 void Lab_ChangeHitDisplay(GOBJ *menu_gobj, int value)
 {
@@ -449,13 +433,10 @@ void Lab_ChangeHitDisplay(GOBJ *menu_gobj, int value)
         // get next fighter
         this_fighter = this_fighter->next;
     }
-
-    return;
 }
 void Lab_ChangeEnvCollDisplay(GOBJ *menu_gobj, int value)
 {
     stc_matchcam->show_coll = value;
-    return;
 }
 void Lab_ChangeItemGrabDisplay(GOBJ *menu_gobj, int value)
 {
@@ -493,8 +474,6 @@ void Lab_ChangeCamMode(GOBJ *menu_gobj, int value)
         Match_SetDevelopCamera();
     }
     Match_CorrectCamera();
-
-    return;
 }
 
 static void Lab_ChangeInfoPreset(EventOption options[], int preset_id)
@@ -2494,8 +2473,6 @@ void DIDraw_Init()
             didraws[i].vertices[j] = 0;
         }
     }
-
-    return;
 }
 void DIDraw_Update()
 {
@@ -2902,8 +2879,6 @@ void DIDraw_Update()
             }
         }
     }
-
-    return;
 }
 void DIDraw_GX()
 {
@@ -2939,7 +2914,6 @@ void DIDraw_GX()
             }
         }
     }
-    return;
 }
 void Update_Camera()
 {
@@ -2987,8 +2961,6 @@ void Update_Camera()
             }
         }
     }
-
-    return;
 }
 
 void CustomTDI_Apply(GOBJ *cpu, GOBJ *hmn, CustomTDI *di)
@@ -3125,8 +3097,6 @@ void Lab_SelectCustomTDI(GOBJ *menu_gobj)
     menu_data->custom_gobj = tdi_gobj;
     menu_data->custom_gobj_destroy = CustomTDI_Destroy;
 
-    return;
-
     /*
     // Change color
     GXColor gx_color = TEXT_BGCOLOR;
@@ -3238,8 +3208,6 @@ void CustomTDI_Update(GOBJ *gobj)
 
     // update jobj
     JOBJ_SetMtxDirtySub(gobj->hsd_object);
-
-    return;
 }
 void CustomTDI_Destroy(GOBJ *gobj)
 {
@@ -3269,8 +3237,6 @@ void CustomTDI_Destroy(GOBJ *gobj)
 
     // play sfx
     SFX_PlayCommon(0);
-
-    return;
 }
 void Inputs_Think(GOBJ *gobj)
 {
@@ -3446,8 +3412,6 @@ void Inputs_Init()
 
     GObj_AddObject(input_gobj, 3, root);                              // add to gobj
     GObj_AddGXLink(input_gobj, GXLink_Common, INPUT_GXLINK, INPUT_GXPRI); // add gx link
-
-    return;
 }
 
 void Record_CopySlot(GOBJ *menu_gobj) {
@@ -3610,8 +3574,6 @@ void Record_CObjThink(GOBJ *gobj)
     {
         CObjThink_Common(gobj);
     }
-
-    return;
 }
 void Record_GX(GOBJ *gobj, int pass)
 {
@@ -3703,8 +3665,6 @@ void Record_GX(GOBJ *gobj, int pass)
     }
 
     GXLink_Common(gobj, pass);
-
-    return;
 }
 void Record_Think(GOBJ *rec_gobj)
 {
@@ -3921,8 +3881,6 @@ void Record_Update(int ply, RecInputData *input_data, int rec_mode)
         }
         }
     }
-
-    return;
 }
 void Record_InitState(GOBJ *menu_gobj)
 {
@@ -4281,8 +4239,6 @@ void Record_OnSuccessfulSave(int deleteRecordings)
 
     // take screenshot
     snap_status = 1;
-
-    return;
 }
 void Memcard_Wait()
 {
@@ -4291,8 +4247,6 @@ void Memcard_Wait()
     {
         blr2();
     }
-
-    return;
 }
 void Record_MemcardLoad(int slot, int file_no)
 {
@@ -4435,8 +4389,6 @@ void Record_MemcardLoad(int slot, int file_no)
         int load_post_tick = OSGetTick();
         int load_time = OSTicksToMilliseconds(load_post_tick - load_pre_tick);
     }
-
-    return;
 }
 int Record_MenuThink(GOBJ *menu_gobj)
 {
@@ -4453,10 +4405,7 @@ int Record_MenuThink(GOBJ *menu_gobj)
 }
 void Record_StartExport(GOBJ *menu_gobj)
 {
-
     export_status = EXSTAT_REQSAVE;
-
-    return;
 }
 
 void Record_LoadSavestate(Savestate *savestate) {
@@ -4588,8 +4537,6 @@ void Savestates_Update()
             }
         }
     }
-
-    return;
 }
 
 // Export functions
@@ -4633,12 +4580,9 @@ void ImageScale(RGB565 *out_img, RGB565 *in_img, int OutWidth, int OutHeight, in
             out_img[in_pixel] = in_img[out_pixel];
         }
     }
-
-    return;
 }
 void Export_Init(GOBJ *menu_gobj)
 {
-
     MenuData *menu_data = menu_gobj->userdata;
     EventMenu *curr_menu = menu_data->currMenu;
     evMenu *menuAssets = event_vars->menu_assets;
@@ -4751,8 +4695,6 @@ void Export_Init(GOBJ *menu_gobj)
     menu_data->custom_gobj = export_gobj;            // set custom gobj
     menu_data->custom_gobj_think = Export_Think;     // set think function
     menu_data->custom_gobj_destroy = Export_Destroy; // set destroy function
-
-    return;
 }
 int Export_Think(GOBJ *export_gobj)
 {
@@ -4812,8 +4754,6 @@ void Export_Destroy(GOBJ *export_gobj)
     menu_data->custom_gobj = 0;
     menu_data->custom_gobj_think = 0;
     menu_data->custom_gobj_destroy = 0;
-
-    return;
 }
 void Export_SelCardInit(GOBJ *export_gobj)
 {
@@ -4877,8 +4817,6 @@ void Export_SelCardInit(GOBJ *export_gobj)
     // init cursor
     export_data->menu_index = EXMENU_SELCARD;
     export_data->slot = 0;
-
-    return;
 }
 int Export_SelCardThink(GOBJ *export_gobj)
 {
@@ -5152,8 +5090,6 @@ void Export_EnterNameInit(GOBJ *export_gobj)
     // init menu variables
     export_data->menu_index = EXMENU_NAME;
     export_data->filename_cursor = 0;
-
-    return;
 }
 int Export_EnterNameThink(GOBJ *export_gobj)
 {
@@ -5605,8 +5541,6 @@ void Export_EnterNameUpdateKeyboard(GOBJ *export_gobj)
             Text_SetColor(text_keyboard, this_subtext, color);
         }
     }
-
-    return;
 }
 int Export_Process(GOBJ *export_gobj)
 {
@@ -6017,8 +5951,6 @@ void Event_Init(GOBJ *gobj)
 
     // Aitch: VERY nice for debugging. Please don't remove.
     TMLOG("HMN: %x\tCPU: %x\n", (u32)hmn_data, (u32)cpu_data);
-
-    return;
 }
 
 // Update Function

--- a/src/lab.c
+++ b/src/lab.c
@@ -534,11 +534,6 @@ void Lab_Exit(int value)
 
     // cleanup
     Match_EndVS();
-
-    // Unfreeze
-    LabOptions_General[OPTGEN_FRAME].option_val = 0;
-    //HSD_Update *update = stc_hsd_update;
-    return;
 }
 
 // Event Functions

--- a/src/lab_css.c
+++ b/src/lab_css.c
@@ -62,8 +62,6 @@ void OnCSSLoad(HSD_Archive *archive)
 
     Cam_Button_Create();
     Hazards_Button_Create();
-
-    return;
 }
 
 void Read_Recordings()
@@ -164,8 +162,6 @@ void Cam_Button_Create()
     button_text->trans.Y = (button_jobj->trans.Y * -1) + (-1.6 * (scale->Y / 4.0));
 
     Text_AddSubtext(button_text, 0, 0, "Import");
-
-    return;
 }
 
 void Cam_Button_Think(GOBJ *button_gobj)
@@ -196,8 +192,6 @@ void Cam_Button_Think(GOBJ *button_gobj)
         import_data.menu_gobj = Menu_Create();
         SFX_PlayCommon(1);
     }
-
-    return;
 }
 
 static char *hazard_button_text_options[] = {"Hazards: On", "Hazards: Off"};
@@ -230,8 +224,6 @@ void Hazards_Button_Create()
 
     char *text = hazard_button_text_options[event_desc->disable_hazards];
     hazard_button_subtext = Text_AddSubtext(hazard_button_text, 0, 0, text);
-
-    return;
 }
 
 void Hazards_Button_Think(GOBJ *button_gobj)
@@ -261,8 +253,6 @@ void Hazards_Button_Think(GOBJ *button_gobj)
         char *new_text = hazard_button_text_options[new_hazard_state];
         Text_SetText(hazard_button_text, hazard_button_subtext, new_text);
     }
-
-    return;
 }
 
 // Import Menu Functions
@@ -352,8 +342,6 @@ void Menu_Destroy(GOBJ *menu_gobj)
     // enable CSS inputs
     *stc_css_exitkind = 0;
     *stc_css_delay = 0;
-
-    return;
 }
 void Menu_Think(GOBJ *menu_gobj)
 {
@@ -378,8 +366,6 @@ void Menu_Think(GOBJ *menu_gobj)
         break;
     }
     }
-
-    return;
 }
 // Select Card
 void Menu_SelCard_Init(GOBJ *menu_gobj)
@@ -416,8 +402,6 @@ void Menu_SelCard_Init(GOBJ *menu_gobj)
 
     // edit description
     Text_SetText(import_data.desc_text, 0, "");
-
-    return;
 }
 void Menu_SelCard_Think(GOBJ *menu_gobj)
 {
@@ -499,8 +483,6 @@ void Menu_SelCard_Think(GOBJ *menu_gobj)
         else
             SFX_PlayCommon(3);
     }
-
-    return;
 }
 void Menu_SelCard_Exit(GOBJ *menu_gobj)
 {
@@ -510,8 +492,6 @@ void Menu_SelCard_Exit(GOBJ *menu_gobj)
     // destroy memcard text
     Text_Destroy(import_data.option_text);
     import_data.option_text = 0;
-
-    return;
 }
 // Select File
 void Menu_SelFile_Init(GOBJ *menu_gobj)
@@ -601,8 +581,6 @@ void Menu_SelFile_Init(GOBJ *menu_gobj)
         Menu_Confirm_Init(menu_gobj, CFRM_ERR);
         SFX_PlayCommon(3);
     }
-
-    return;
 }
 void Menu_SelFile_Think(GOBJ *menu_gobj)
 {
@@ -743,8 +721,6 @@ void Menu_SelFile_Think(GOBJ *menu_gobj)
         Menu_Confirm_Init(menu_gobj, kind);
         SFX_PlayCommon(1);
     }
-
-    return;
 }
 void Menu_SelFile_Exit(GOBJ *menu_gobj)
 {
@@ -784,8 +760,6 @@ void Menu_SelFile_Exit(GOBJ *menu_gobj)
             import_data.snap.file_data[i] = 0;
         }
     }
-
-    return;
 }
 int Menu_SelFile_LoadPage(GOBJ *menu_gobj, int page)
 {
@@ -1021,8 +995,6 @@ void Menu_Confirm_Init(GOBJ *menu_gobj, int kind)
         break;
     }
     }
-
-    return;
 }
 
 void Menu_Left_Right(int down, u8* cursor)
@@ -1250,8 +1222,6 @@ void Menu_Confirm_Think(GOBJ *menu_gobj)
         break;
     }
     }
-
-    return;
 }
 void Menu_Confirm_Exit(GOBJ *menu_gobj)
 {
@@ -1262,20 +1232,15 @@ void Menu_Confirm_Exit(GOBJ *menu_gobj)
     // destroy gobj
     GObj_Destroy(import_data.confirm.gobj);
     import_data.confirm.gobj = 0;
-
-    return;
 }
 
 // Misc functions
 void Memcard_Wait()
 {
-
     while (stc_memcard_work->is_done == 0)
     {
         blr2();
     }
-
-    return;
 }
 ExportHeader *GetExportHeaderFromCard(int slot, char *fileName, void *buffer) {
     CARDFileInfo card_file_info;

--- a/src/lcancel.c
+++ b/src/lcancel.c
@@ -121,11 +121,6 @@ void Event_Exit()
 
     // cleanup
     Match_EndVS();
-
-    // unfreeze
-    HSD_Update *update = stc_hsd_update;
-    update->pause_kind = PAUSEKIND_NONE;
-    return;
 }
 
 // L-Cancel functions

--- a/src/lcancel.c
+++ b/src/lcancel.c
@@ -91,8 +91,6 @@ void Event_Init(GOBJ *gobj)
 
     // set CPU AI to no_act 15
     //cpu_data->cpu.ai = 0;
-
-    return;
 }
 // Think Function
 void Event_Think(GOBJ *event)
@@ -109,8 +107,6 @@ void Event_Think(GOBJ *event)
 
     LCancel_Think(event_data, hmn_data);
     Barrel_Think(event_data);
-
-    return;
 }
 void Event_Exit()
 {
@@ -319,8 +315,6 @@ void LCancel_Think(LCancelData *event_data, FighterData *hmn_data)
 
     // update HUD anim
     JOBJ_AnimAll(hud_jobj);
-
-    return;
 }
 void LCancel_HUDCamThink(GOBJ *gobj)
 {
@@ -330,8 +324,6 @@ void LCancel_HUDCamThink(GOBJ *gobj)
     {
         CObjThink_Common(gobj);
     }
-
-    return;
 }
 
 // Tips Functions
@@ -340,8 +332,6 @@ void Tips_Toggle(GOBJ *menu_gobj, int value)
     // destroy existing tips when disabling
     if (value == 1)
         event_vars->Tip_Destroy();
-
-    return;
 }
 void Tips_Think(LCancelData *event_data, FighterData *hmn_data)
 {
@@ -490,7 +480,6 @@ void Tips_Think(LCancelData *event_data, FighterData *hmn_data)
             }
         }
     }
-    return;
 }
 
 // Barrel Functions
@@ -589,8 +578,6 @@ void Barrel_Think(LCancelData *event_data)
         break;
     }
     }
-
-    return;
 }
 GOBJ *Barrel_Spawn(int pos_kind)
 {
@@ -706,11 +693,10 @@ GOBJ *Barrel_Spawn(int pos_kind)
 }
 void Barrel_Null()
 {
-    return;
+    return; // Do nothing on purpose
 }
 void Barrel_Break(GOBJ *barrel_gobj)
 {
-
     ItemData *barrel_data = barrel_gobj->userdata;
     Effect_SpawnSync(1063, barrel_gobj, &barrel_data->pos);
     SFX_Play(251);
@@ -724,8 +710,6 @@ void Barrel_Break(GOBJ *barrel_gobj)
     barrel_data->item_var.var2 = 40;
     barrel_data->xdcf3 = 1;
     ItemStateChange(barrel_gobj, 7, 2);
-
-    return;
 }
 int Barrel_OnHurt(GOBJ *barrel_gobj)
 {

--- a/src/ledgedash.c
+++ b/src/ledgedash.c
@@ -209,8 +209,6 @@ void Event_Init(GOBJ *gobj)
     Ledgedash_FtInit(event_data);
 
     Fighter_PlaceOnLedge();
-
-    return;
 }
 // Think Function
 void Event_Think(GOBJ *event)
@@ -271,9 +269,6 @@ void Event_Think(GOBJ *event)
             hmn_data->color[1].color_enable = 1;
         }
     }
-
-
-    return;
 }
 void Event_Exit()
 {
@@ -284,8 +279,6 @@ void Event_Exit()
 
     // cleanup
     Match_EndVS();
-
-    return;
 }
 
 // Ledgedash functions
@@ -559,16 +552,12 @@ void Ledgedash_HUDThink(LedgedashData *event_data, FighterData *hmn_data)
 
     // update HUD anim
     JOBJ_AnimAll(hud_jobj);
-
-    return;
 }
 void Ledgedash_HUDCamThink(GOBJ *gobj)
 {
     // if HUD enabled and not paused
     if (LdshOptions_Main[OPT_HUD].option_val == 0 && Pause_CheckStatus(1) != 2)
         CObjThink_Common(gobj);
-
-    return;
 }
 
 void Ledgedash_ResetThink(LedgedashData *event_data, GOBJ *hmn)
@@ -634,8 +623,6 @@ void Ledgedash_ResetThink(LedgedashData *event_data, GOBJ *hmn)
             SFX_PlayCommon(3);
         }
     }
-
-    return;
 }
 void Ledgedash_InitVariables(LedgedashData *event_data)
 {
@@ -660,8 +647,6 @@ void Ledgedash_ToggleStartPosition(GOBJ *menu_gobj, int value)
     LedgedashData *event_data = event_vars->event_gobj->userdata;
 
     Fighter_PlaceOnLedge();
-
-    return;
 }
 
 // Hitlog functions
@@ -744,8 +729,6 @@ void Ledgedash_HitLogThink(LedgedashData *event_data, GOBJ *hmn)
             this_item = this_item->next;
         }
     }
-
-    return;
 }
 void Ledgedash_HitLogGX(GOBJ *gobj, int pass)
 {
@@ -774,8 +757,6 @@ void Ledgedash_HitLogGX(GOBJ *gobj, int pass)
 
         Develop_DrawSphere(this_ldsh_hit->size, &this_ldsh_hit->pos_curr, &this_ldsh_hit->pos_prev, diffuse, &hitlog_ambient);
     }
-
-    return;
 }
 
 // Fighter fuctions
@@ -803,8 +784,6 @@ void Ledgedash_FtInit(LedgedashData *event_data)
     //    event_data->cam->is_disable = 0;
     //    event_vars->Tip_Display(500 * 60, "Error:\nIt appears there are no\ngood ledges on this stage...");
     //}
-
-    return;
 }
 
 void Ledgedash_ChangeCamMode(GOBJ *menu_gobj, int value)
@@ -833,8 +812,6 @@ void Ledgedash_ChangeCamMode(GOBJ *menu_gobj, int value)
         Match_SetDevelopCamera();
     }
     Match_CorrectCamera();
-
-    return;
 }
 
 void Event_Update()
@@ -895,8 +872,6 @@ void Update_Camera()
             }
         }
     }
-
-    return;
 }
 
 int Ledge_Find(int search_dir, float xpos_start, float *ledge_dir)
@@ -1230,8 +1205,6 @@ void Fighter_PlaceOnLedge(void)
 
         gobj = gobj_next;
     }
-
-    return;
 }
 void Fighter_UpdatePosition(GOBJ *fighter)
 {
@@ -1260,7 +1233,6 @@ void Fighter_UpdatePosition(GOBJ *fighter)
 
     // Update Static Player Block Coords
     Fighter_SetPosition(fighter_data->ply, fighter_data->flags.ms, &fighter_data->phys.pos);
-    return;
 }
 void Fighter_UpdateCamera(GOBJ *fighter)
 {
@@ -1287,8 +1259,6 @@ void RebirthWait_Phys(GOBJ *fighter)
 
     // infinite time
     fighter_data->state_var.state_var1 = 2;
-
-    return;
 }
 int RebirthWait_IASA(GOBJ *fighter)
 {
@@ -1349,8 +1319,6 @@ void Tips_Toggle(GOBJ *menu_gobj, int value)
     // destroy existing tips when disabling
     if (value == 1)
         event_vars->Tip_Destroy();
-
-    return;
 }
 void Tips_Think(LedgedashData *event_data, FighterData *hmn_data)
 {

--- a/src/wavedash.c
+++ b/src/wavedash.c
@@ -119,11 +119,6 @@ void Event_Exit()
 
     // cleanup
     Match_EndVS();
-
-    // unfreeze
-    HSD_Update *update = stc_hsd_update;
-    update->pause_kind = PAUSEKIND_NONE;
-    return;
 }
 
 // Event functions

--- a/src/wavedash.c
+++ b/src/wavedash.c
@@ -93,8 +93,6 @@ void Event_Init(GOBJ *gobj)
 
     // init target
     Target_Init(event_data, hmn_data);
-
-    return;
 }
 // Think Function
 void Event_Think(GOBJ *event)
@@ -107,8 +105,6 @@ void Event_Think(GOBJ *event)
     hmn_data->shield.health = 60;
 
     Wavedash_Think(event_data, hmn_data);
-
-    return;
 }
 void Event_Exit()
 {
@@ -454,8 +450,6 @@ void Wavedash_Think(WavedashData *event_data, FighterData *hmn_data)
         arrow_jobj->trans.X = xpos;
         JOBJ_SetMtxDirtySub(arrow_jobj);
     }
-
-    return;
 }
 void Wavedash_HUDCamThink(GOBJ *gobj)
 {
@@ -465,8 +459,6 @@ void Wavedash_HUDCamThink(GOBJ *gobj)
     {
         CObjThink_Common(gobj);
     }
-
-    return;
 }
 float Bezier(float time, float start, float end)
 {
@@ -511,8 +503,6 @@ void Target_Init(WavedashData *event_data, FighterData *hmn_data)
 
     // free jobj
     JOBJ_RemoveAll(target);
-
-    return;
 }
 void Target_Manager(WavedashData *event_data, FighterData *hmn_data)
 {
@@ -566,8 +556,6 @@ void Target_Manager(WavedashData *event_data, FighterData *hmn_data)
         break;
     }
     }
-
-    return;
 }
 GOBJ *Target_Spawn(WavedashData *event_data, FighterData *hmn_data)
 {
@@ -752,8 +740,6 @@ void Target_Think(GOBJ *target_gobj)
         break;
     }
     }
-
-    return;
 }
 void Target_ChangeState(GOBJ *target_gobj, int state)
 {
@@ -767,8 +753,6 @@ void Target_ChangeState(GOBJ *target_gobj, int state)
     // add anim
     JOBJ_AddAnimAll(target_jobj, event_data->assets->target_jointanim[state], event_data->assets->target_matanim[state], 0);
     JOBJ_ReqAnimAll(target_jobj, 0); // req anim
-
-    return;
 }
 float Target_GetWdashDistance(FighterData *hmn_data, float mag)
 {
@@ -847,8 +831,6 @@ Tips_Think(WavedashData *event_data, FighterData *hmn_data)
             }
         }
     }
-
-    return;
 }
 
 // Initial Menu


### PR DESCRIPTION
This unfreeze code seems unnecessary. It doesn't exist in other events, so I removed it and things work fine. Stops the A input when hitting exits from flashing the hud and inputting a jab.

I also went through and removed a bunch of redundant return statements at the end of void functions.