### PR TITLE
Added instructions for MacOS support

### DIFF
--- a/TM-CE/build_linux_mac.sh
+++ b/TM-CE/build_linux_mac.sh
@@ -3,14 +3,14 @@
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 XDELTA_PATCH_PATH="$SCRIPT_DIR/patch.xdelta"
 
-echo Hi fellow linux users! Consider contributing to TM-CE if you have a bit of free time. - Aitch
+echo Hi fellow linux & mac users! Consider contributing to TM-CE if you have a bit of free time. - Aitch
 
 if command -v xdelta3 > /dev/null; then
     XDELTA_CMD="xdelta3"
 elif command -v xdelta > /dev/null; then
     XDELTA_CMD="xdelta"
 else
-    echo "ERROR: xdelta is not installed. Please install xdelta or xdelta3 through your package manager."
+    echo "ERROR: xdelta is not installed. Please install xdelta or xdelta3 through your package manager. MacOS users can use brew to install xdelta."
     exit 1
 fi
 


### PR DESCRIPTION
Not sure if you were aware, but `build_linux.sh` actually runs perfectly on MacOS provided you have xdelta installed. Updated script name and error message for additional details for building on MacOS.

Tested on MacOS Sequoia 15.3.1 (M1 Macbook Pro)