### PR TITLE
add edge cancel detection to L-Cancel training

### DIFF
--- a/src/lcancel.c
+++ b/src/lcancel.c
@@ -205,7 +205,7 @@ void LCancel_Think(LCancelData *event_data, FighterData *hmn_data)
     {
         // did i fastfall yet?
         if (hmn_data->flags.is_fastfall)
-            event_data->is_fastfall = 1; // set as fastfall this session
+            event_data->is_fastfall = true; // set as fastfall this session
         else
             event_data->fastfall_frame++; // increment frames
     }
@@ -238,19 +238,19 @@ void LCancel_Think(LCancelData *event_data, FighterData *hmn_data)
         event_data->hud.lcl_total++;
 
         // determine succession
-        int is_fail = 1;
+        bool is_fail = true;
         if (is_success_l_cancel || is_edge_cancel)
         {
-            is_fail = 0;
+            is_fail = false;
             event_data->hud.lcl_success++;
         }
         event_data->is_fail = is_fail; // save l-cancel bool
 
         // Play appropriate sfx
-        if (is_fail == 0)
-            SFX_PlayRaw(303, 255, 128, 20, 3);
-        else
+        if (is_fail)
             SFX_PlayCommon(3);
+        else
+            SFX_PlayRaw(303, 255, 128, 20, 3);
 
         // update timing text
         int frame_box_id;
@@ -338,7 +338,7 @@ void LCancel_Think(LCancelData *event_data, FighterData *hmn_data)
     if (!can_fastfall && !is_aerial_landing_state(state)) // cant fastfall, reset frames
     {
         event_data->fastfall_frame = 0;
-        event_data->is_fastfall = 0;
+        event_data->is_fastfall = false;
     }
 
     // update HUD anim
@@ -418,7 +418,7 @@ void Tips_Think(LCancelData *event_data, FighterData *hmn_data)
 
             // update tip conditions
             if ((hmn_data->state_id >= ASID_LANDINGAIRN) && (hmn_data->state_id <= ASID_LANDINGAIRLW) && (hmn_data->TM.state_frame == 0) && // is in aerial landing
-                (event_data->is_fail == 0) &&
+                (!event_data->is_fail) &&
                 (event_data->tip.hitbox_active == 0)) // succeeded the last aerial landing
             {
                 // increment condition count
@@ -452,7 +452,7 @@ void Tips_Think(LCancelData *event_data, FighterData *hmn_data)
                     event_data->tip.fastfall_active = 0;
 
                 // check if fastfalling
-                if (hmn_data->flags.is_fastfall == 1)
+                if (hmn_data->flags.is_fastfall)
                     event_data->tip.fastfall_active = 1;
             }
 
@@ -486,7 +486,7 @@ void Tips_Think(LCancelData *event_data, FighterData *hmn_data)
 
             // update tip conditions
             if ((hmn_data->state_id >= ASID_LANDINGAIRN) && (hmn_data->state_id <= ASID_LANDINGAIRLW) && // is in aerial landing
-                (event_data->is_fail == 1) &&                                                      // failed the l-cancel
+                (event_data->is_fail) &&                                                      // failed the l-cancel
                 (hmn_data->input.down & (HSD_TRIGGER_L | HSD_TRIGGER_R | HSD_TRIGGER_Z)))          // was late for an l-cancel by pressing it just now
             {
                 // increment condition count

--- a/src/lcancel.h
+++ b/src/lcancel.h
@@ -13,6 +13,8 @@ struct LCancelData
     u8 is_fail;        // status of the last l-cancel
     u8 is_fastfall;    // bool used to detect fastfall frame
     u8 fastfall_frame; // frame the player fastfell on
+    u8 current_l_input_timing;    // number of frames an L was input before the current aerial landing
+    u8 is_current_aerial_counted; // whether or not the current aerial has already been tracked as a success or failure 
     struct
     {
         GOBJ *gobj;
@@ -62,3 +64,5 @@ void Barrel_Toggle(GOBJ *menu_gobj, int value);
 GOBJ *Barrel_Spawn(int pos_kind);
 void Barrel_Null();
 void Event_Exit();
+bool is_aerial_landing_state(int state_id);
+bool is_edge_cancel_state(int state_id);

--- a/src/lcancel.h
+++ b/src/lcancel.h
@@ -10,11 +10,11 @@ struct LCancelData
     LCancelAssets *lcancel_assets;
     GOBJ *barrel_gobj;
     Vec3 barrel_lastpos;
-    u8 is_fail;        // status of the last l-cancel
-    u8 is_fastfall;    // bool used to detect fastfall frame
+    bool is_fail;      // status of the last l-cancel
+    bool is_fastfall;  // bool used to detect fastfall frame
     u8 fastfall_frame; // frame the player fastfell on
-    u8 current_l_input_timing;    // number of frames an L was input before the current aerial landing
-    u8 is_current_aerial_counted; // whether or not the current aerial has already been tracked as a success or failure 
+    u8 current_l_input_timing;      // number of frames an L was input before the current aerial landing
+    bool is_current_aerial_counted; // whether or not the current aerial has already been tracked as a success or failure
     struct
     {
         GOBJ *gobj;


### PR DESCRIPTION
Add edge cancel detection to the L-Cancel event.

Before this change, the detection worked as follows:

- if first frame of aerial landing
  - if correct L was input: count success
  - else: count miss

Since edge cancels happen after aerial landing, we need to delay counting success/miss/edge cancel until after the first frame in some cases. The new detection works as follows:

- if first frame of aerial landing && correct L input: count success
- else if missed L cancel && no horizontal trajectory && (current landing frame > num of frames in L-cancelled landing animation): count miss
- else if state in (FALL, TEETER) && last state was aerial landing: count success (edge cancel)

There's a `is_current_aerial_counted` flag to make sure each aerial only gets counted once per aerial (e.g. L Cancel success into Edge Cancel only gets counted as an L Cancel).

A few things to note about this approach edge cancel detection:

- Success L-Cancels will are always tracked as L-Cancels, even if they're edge cancelled. I played around with having edge cancels also override successful L-Cancels, but it feels wrong to not have the Success sound play on the first frame of a successful L-Cancel.
- The sound for missed L-Cancels doesn't necessarily play on the first frame of landing anymore.
- If a missed aerial is edge cancelled, but the number of frames spent in landing animation is greater than the number of frames for the L-Cancelled animation variation, it's treated as a miss. E.g. edge cancelling Marth's fair after 8 frames of landing animation.

General demo video:

https://github.com/user-attachments/assets/c77e28f1-162a-44fc-8be9-b54e5b76b2ef

