### PR TITLE
fix l-cancel event arrow bug

### DIFF
--- a/src/lcancel.c
+++ b/src/lcancel.c
@@ -253,22 +253,19 @@ void LCancel_Think(LCancelData *event_data, FighterData *hmn_data)
             SFX_PlayRaw(303, 255, 128, 20, 3);
 
         // update timing text
-        int frame_box_id;
         if (is_edge_cancel)
         {
             Text_SetText(event_data->hud.text_time, 0, "EC %df", hmn_data->TM.state_prev_frames[0]);
         }
-        else if (event_data->current_l_input_timing >= 30)
+        else if (event_data->current_l_input_timing > MAX_L_PRESS_TIMING)
         {
-            // update text
             Text_SetText(event_data->hud.text_time, 0, "No Press");
-            frame_box_id = 29;
         }
         else
         {
             Text_SetText(event_data->hud.text_time, 0, "%df/7f", event_data->current_l_input_timing + 1);
-            frame_box_id = event_data->current_l_input_timing;
         }
+        int frame_box_id = min(event_data->current_l_input_timing, MAX_L_PRESS_TIMING);
 
         // update arrow
         JOBJ *arrow_jobj;
@@ -789,6 +786,10 @@ bool is_aerial_landing_state(int state_id) {
 
 bool is_edge_cancel_state(int state_id) {
     return (state_id == ASID_FALL || state_id == ASID_OTTOTTO);
+}
+
+int min(int a, int b) {
+    return (((a) < (b)) ? (a) : (b));
 }
 
 static void *item_callbacks[] = {

--- a/src/lcancel.h
+++ b/src/lcancel.h
@@ -55,6 +55,9 @@ typedef struct LCancelAssets
 #define LCLARROW_JOBJ 7
 #define LCLARROW_OFFSET 0.365
 
+// Maximum number of frames before a miss is considered "No Press", using zero-based indexing.
+#define MAX_L_PRESS_TIMING 29
+
 static void *item_callbacks[];
 float Bezier(float time, float start, float end);
 void Tips_Toggle(GOBJ *menu_gobj, int value);
@@ -66,3 +69,4 @@ void Barrel_Null();
 void Event_Exit();
 bool is_aerial_landing_state(int state_id);
 bool is_edge_cancel_state(int state_id);
+int min(int a, int b);


### PR DESCRIPTION
There's an issue in the L-Cancel training event where the arrow isn't displayed correctly after an edge-cancel:

https://github.com/user-attachments/assets/9cb40cd9-33d6-4ac0-97a5-6990b3764295

This was introduced by a514d249ccb239febbec1f17d507d7be2c5b6eca and happens because `frame_box_id` (the index for the box that the timing arrow should point to) wasn't getting initialized for the edge cancel case. This resulted in a really large number getting used as the index, instead of something between 0-29, and that messed up the animation for some reason.

To fix this I simplified the arrow index logic to just be `min(l_press_timing, 29)` for all cases (success, miss, edge cancel).

https://github.com/user-attachments/assets/07e31c0f-ee0e-4ffd-948d-bc7fe6317c33

