### PR TITLE
Improve dev console code

### DIFF
--- a/MexTK/include/devtext.h
+++ b/MexTK/include/devtext.h
@@ -23,6 +23,7 @@ struct DevText
     char x25;                 // 0x25
     char show_text : 1;       // 0x26
     char show_background : 1; // 0x26
+    char x26_20 : 1;          // 0x26
     char show_cursor : 1;     // 0x26
     char x27;                 // 0x27
     u8 *text_data;            // 0x28

--- a/src/events.c
+++ b/src/events.c
@@ -1320,8 +1320,7 @@ void EventUpdate()
 void TM_ConsoleThink(GOBJ *gobj)
 {
     // init variables
-    int *data = gobj->userdata;
-    DevText *text = data[0];
+    DevText *text = gobj->userdata;
 
     // check to toggle console
     for (int i = 0; i < 4; i++)
@@ -1345,15 +1344,14 @@ void TM_ConsoleThink(GOBJ *gobj)
 void TM_CreateConsole()
 {
     // init dev text
-    GOBJ *gobj = GObj_Create(0, 0, 0);
-    int *data = calloc(32);
-    GObj_AddUserData(gobj, 4, HSD_Free, data);
-    GObj_AddProc(gobj, TM_ConsoleThink, 0);
-
     DevText *text = DevelopText_CreateDataTable(13, 0, 0, 32, 32, HSD_MemAlloc(0x1000));
     DevelopText_Activate(0, text);
     text->show_cursor = 0;
-    data[0] = text;
+
+    GOBJ *gobj = GObj_Create(0, 0, 0);
+    GObj_AddUserData(gobj, 4, HSD_Free, text);
+    GObj_AddProc(gobj, TM_ConsoleThink, 0);
+
     GXColor color = {21, 20, 59, 80};
     DevelopText_StoreBGColor(text, &color);
     DevelopText_StoreTextScale(text, 10, 12);

--- a/src/events.c
+++ b/src/events.c
@@ -1319,27 +1319,20 @@ void EventUpdate()
 
 void TM_ConsoleThink(GOBJ *gobj)
 {
-    // init variables
     DevText *text = gobj->userdata;
 
-    // check to toggle console
+    // Toggle console with L/R + Z
     for (int i = 0; i < 4; i++)
     {
         HSD_Pad *pad = PadGet(i, PADGET_MASTER);
         if (pad->held & (HSD_TRIGGER_L | HSD_TRIGGER_R) && (pad->down & HSD_TRIGGER_Z))
         {
-            // toggle visibility
             text->show_text ^= 1;
             text->show_background ^= 1;
             show_console ^= 1;
-
             break;
         }
     }
-
-    // clear text
-    //DevelopText_EraseAllText(text);
-    //DevelopMode_ResetCursorXY(text, 0, 0);
 }
 void TM_CreateConsole()
 {

--- a/src/events.c
+++ b/src/events.c
@@ -1095,7 +1095,6 @@ static EventVars stc_event_vars = {
 };
 static Savestate *stc_savestate;
 static EventDesc *static_eventInfo;
-static int show_console = 1;
 static int *eventDataBackup;
 static TipMgr stc_tipmgr;
 
@@ -1329,7 +1328,6 @@ void TM_ConsoleThink(GOBJ *gobj)
         {
             text->show_text ^= 1;
             text->show_background ^= 1;
-            show_console ^= 1;
             break;
         }
     }
@@ -1349,13 +1347,6 @@ void TM_CreateConsole()
     DevelopText_StoreBGColor(text, &color);
     DevelopText_StoreTextScale(text, 10, 12);
     stc_event_vars.db_console_text = text;
-
-    if (show_console != 1)
-    {
-        // toggle visibility
-        DevelopText_HideBG(text);
-        DevelopText_HideText(text);
-    }
 }
 
 void OnFileLoad(HSD_Archive *archive) // this function is run right after TmDt is loaded into memory on boot


### PR DESCRIPTION
Noticed a bitfield discrepancy fixed in Kellz's m-ex fork: https://github.com/sadkellz/m-ex

Now the `text->show_cursor = 0` actually disables the blinking cursor on the dev console. Of course, it can be added back by removing that line.

Took the opportunity to clean up that code a little.