### PR TITLE
Add "top right" to OSD Position

### DIFF
--- a/ASM/training-mode/Onscreen Display/Toggle UI/Load Alt Text When Loaded With L.asm
+++ b/ASM/training-mode/Onscreen Display/Toggle UI/Load Alt Text When Loaded With L.asm
@@ -99,7 +99,7 @@ IncLoopLeft:
     lbz r5, 0x1F28(r5)
 
     # Fix value if invalid from removed max osd setting
-    cmpwi r5, 3
+    cmpwi r5, 4
     blt EndFixInvalidOSDPosition
     li r5, 0
 EndFixInvalidOSDPosition:
@@ -109,7 +109,9 @@ EndFixInvalidOSDPosition:
     cmpwi r5, 1
     beql OSDPositionTextSides
     cmpwi r5, 2
-    beql OSDPositionTextTop
+    beql OSDPositionTextTopLeft
+    cmpwi r5, 3
+    beql OSDPositionTextTopRight
     mflr r5
 
     lfs f1, 0x1C(TextProp)
@@ -274,9 +276,14 @@ OSDPositionTextSides:
     .string "Sides"
     .align 2
 
-OSDPositionTextTop:
+OSDPositionTextTopLeft:
     blrl
-    .string "Top"
+    .string "Top Left"
+    .align 2
+
+OSDPositionTextTopRight:
+    blrl
+    .string "Top Right"
     .align 2
 
 XYText:

--- a/ASM/training-mode/Onscreen Display/Toggle UI/XY To Adjust OSD Position.asm
+++ b/ASM/training-mode/Onscreen Display/Toggle UI/XY To Adjust OSD Position.asm
@@ -5,7 +5,7 @@
     .set Text, 30
     .set TextProp, 28
 
-    .set OptionCount, 3
+    .set OptionCount, 4
 
 # Injected into CursorMovement Check
 
@@ -75,7 +75,9 @@ UpdateText:
     cmpwi r6, 1
     beql OSDPositionTextSides
     cmpwi r6, 2
-    beql OSDPositionTextTop
+    beql OSDPositionTextTopLeft
+    cmpwi r6, 3
+    beql OSDPositionTextTopRight
     mflr r6
 
     branchl r12, Text_UpdateSubtextContents
@@ -99,9 +101,14 @@ OSDPositionTextSides:
     .string "Sides"
     .align 2
 
-OSDPositionTextTop:
+OSDPositionTextTopLeft:
     blrl
-    .string "Top"
+    .string "Top Left"
+    .align 2
+
+OSDPositionTextTopRight:
+    blrl
+    .string "Top Right"
     .align 2
 
 ########################################

--- a/src/events.c
+++ b/src/events.c
@@ -2526,7 +2526,7 @@ void Message_Manager(GOBJ *mngr_gobj)
 
                 Memcard *memcard = R13_PTR(MEMCARD);
                 int osd_pos_type = memcard->TM_OSDPosition;
-                if (osd_pos_type > 2)
+                if (osd_pos_type > 3)
                     osd_pos_type = 0;
 
                 Vec3 base_pos;
@@ -2548,6 +2548,11 @@ void Message_Manager(GOBJ *mngr_gobj)
                     // top
                     base_pos = stc_msg_queue_pos_top[i];
                     pos_delta = stc_msg_queue_offsets_horizontal[i];
+                    if (osd_pos_type == 3) {
+                        // top right
+                        base_pos.X *= -1;
+                        pos_delta.X *= -1;
+                    }
                 }
 
                 // Get the onscreen position for this queue

--- a/src/lab_common.h
+++ b/src/lab_common.h
@@ -451,7 +451,7 @@ void Record_Think(GOBJ *rec_gobj);
 void Record_Update(int ply, RecInputData *inputs, int rec_mode);
 void Record_SetInputs(GOBJ *fighter, RecInputs *inputs, bool mirror);
 int Record_RearrangeButtons(RecInputs *inputs);
-void Record_LoadSavestate();
+void Record_LoadSavestate(Savestate *savestate);
 int Record_MenuThink(GOBJ *menu_gobj);
 int Record_OptimizedSave(Savestate *savestate);
 int Record_OptimizedLoad(Savestate *savestate);


### PR DESCRIPTION
Small note: [This](https://github.com/FluentCoding/TrainingMode-CommunityEdition/blob/f4b2939346aa67dbd722623b5dc704ff0d763ff8/src/events.c#L2551-L2555) running every frame shouldn't be of concern I think.