### PR TITLE
Reset nana in edgeguard event

### DIFF
--- a/src/edgeguard.c
+++ b/src/edgeguard.c
@@ -20,8 +20,19 @@ static inline float Progress(float n, float a, float b) { return (n - a) / (b - 
 
 EventMenu *Event_Menu = &Menu_Main;
 
-static void UpdatePosition(GOBJ *fighter) {
-    FighterData *data = fighter->userdata;
+static void ResetPosition(FighterData *data, int side_idx) {
+    int side = side_idx * 2 - 1;
+    float ledge_x = ledge_positions[side_idx].X - DISTANCE_FROM_LEDGE * side;
+
+    data->facing_direction = -side; 
+    
+    // set phys
+    data->phys.kb_vel.X = 0.f;
+    data->phys.kb_vel.Y = 0.f;
+    data->phys.self_vel.X = 0.f;
+    data->phys.self_vel.Y = 0.f;
+    data->phys.pos.X = ledge_x;
+    data->phys.pos.Y = 0.f;
 
     Vec3 pos = data->phys.pos;
     data->coll_data.topN_Curr = pos;
@@ -187,28 +198,8 @@ static void Reset(void) {
     int side_idx = HSD_Randi(2);
     int side = side_idx * 2 - 1;
 
-    hmn_data->facing_direction = -side; 
-    cpu_data->facing_direction = -side;
-
-    float ledge_x = ledge_positions[side_idx].X - DISTANCE_FROM_LEDGE * side;
-    
-    // set phys
-    cpu_data->phys.kb_vel.X = 0.f;
-    cpu_data->phys.kb_vel.Y = 0.f;
-    cpu_data->phys.self_vel.X = 0.f;
-    cpu_data->phys.self_vel.Y = 0.f;
-    hmn_data->phys.kb_vel.X = 0.f;
-    hmn_data->phys.kb_vel.Y = 0.f;
-    hmn_data->phys.self_vel.X = 0.f;
-    hmn_data->phys.self_vel.Y = 0.f;
-
-    hmn_data->phys.pos.X = ledge_x;
-    hmn_data->phys.pos.Y = 0.f;
-    cpu_data->phys.pos.X = ledge_x;
-    cpu_data->phys.pos.Y = 0.f;
-
-    UpdatePosition(hmn);
-    UpdatePosition(cpu);
+    ResetPosition(hmn_data, side_idx);
+    ResetPosition(cpu_data, side_idx);
     
     cpu_data->jump.jumps_used = 1;
     hmn_data->jump.jumps_used = 1;

--- a/src/edgeguard.c
+++ b/src/edgeguard.c
@@ -200,9 +200,6 @@ static void Reset(void) {
 
     ResetPosition(hmn_data, side_idx);
     ResetPosition(cpu_data, side_idx);
-    
-    cpu_data->jump.jumps_used = 1;
-    hmn_data->jump.jumps_used = 1;
 
     // set hmn action state
     Fighter_EnterAerial(hmn, ASID_ATTACKAIRB);

--- a/src/edgeguard.c
+++ b/src/edgeguard.c
@@ -258,6 +258,21 @@ static void Reset(void) {
     int hmn_dmg = Options_Main[OPT_MAIN_PERCENT].val;
     hmn_data->dmg.percent = hmn_dmg;
     Fighter_SetHUDDamage(hmn_data->ply, hmn_dmg);
+
+    GOBJ *follower = Fighter_GetSubcharGObj(hmn_data->ply, 1);
+    if (follower) {
+        FighterData * follower_data = follower->userdata;
+        ResetPosition(follower_data, side_idx);
+        Fighter_EnterAerial(follower, ASID_ATTACKAIRB);
+        Fighter_ApplyAnimation(follower, 7, 1, 0);
+        follower_data->state.frame = 7;
+        follower_data->script.script_event_timer = 0;
+        Fighter_SubactionFastForward(follower);
+        Fighter_UpdateStateFrameInfo(follower);
+        Fighter_HitboxDisableAll(follower);
+        follower_data->script.script_current = 0;
+        follower_data->dmg.percent = hmn_dmg;
+    }
 }
 
 static void ChangePlayerPercent(GOBJ *menu_gobj, int dmg) {


### PR DESCRIPTION
Fixes #220 

For some reason nana doesn't appear in the correct spot, but only when the side of the stage switches. I could not figure out a fix, but at least the current behavior is better. Otherwise made some minor refactors.