### PR TITLE
[L-Cancel Training] add "Target's Intangibility Rate" Option

### DIFF
--- a/src/lcancel.h
+++ b/src/lcancel.h
@@ -10,6 +10,7 @@ struct LCancelData
     LCancelAssets *lcancel_assets;
     GOBJ *barrel_gobj;
     Vec3 barrel_lastpos;
+    int barrel_intangible_timer; // frame counter for intangible cycles (0-119)
     bool is_fail;      // status of the last l-cancel
     bool is_fastfall;  // bool used to detect fastfall frame
     u8 fastfall_frame; // frame the player fastfell on
@@ -61,9 +62,11 @@ struct LCancelAssets
 void Tips_Toggle(GOBJ *menu_gobj, int value);
 void Tips_Think(LCancelData *event_data, FighterData *hmn_data);
 void LCancel_Think(LCancelData *event_data, FighterData *hmn_data);
+void LCancel_ChangeBarrel(GOBJ *gobj, int value);
 void LCancel_ChangeShowHUD(GOBJ *gobj, int show);
 void LCancel_Init(LCancelData *event_data);
 void Barrel_Think(LCancelData *event_data);
+int Barrel_Intangibility_Duration(void);
 void Barrel_Toggle(GOBJ *menu_gobj, int value);
 GOBJ *Barrel_Spawn(int pos_kind);
 int Barrel_OnHurt(GOBJ *barrel_gobj);


### PR DESCRIPTION
https://youtu.be/B3SKYCXr12c

I often mistake L-canceling when I think my aerial will hit and occur hitlag but actually no-hit and no-hitlag because of opponent's dodging or dashing-back
So I want to practice L-canceling input for both situations.