### PR TITLE
Simplify wavedash logic and add short hop indicator

### DIFF
--- a/MexTK/include/math.h
+++ b/MexTK/include/math.h
@@ -38,7 +38,7 @@ static inline float Vec2_Magnitude(Vec2 *v)
 
 /*** Functions ***/
 // float fmod(float a, float b);
-// float atan(float in);
+float atan(float in);
 float atan2(float y, float x);
 float sin(float x);
 float cos(float x);

--- a/src/wavedash.c
+++ b/src/wavedash.c
@@ -642,9 +642,21 @@ void Tips_Think(WavedashData *event_data, FighterData *hmn_data)
     if (hmn_data->state_id == ASID_GUARDOFF && hmn_data->TM.state_frame == 0 &&
         hmn_data->TM.state_prev[3] == ASID_LANDINGFALLSPECIAL)
     {
-        event_data->tip.shield_num++;
-        if (event_data->tip.shield_num % 5 == 2)
+        if (event_data->tip.shield_num++ % 5 == 2)
             event_vars->Tip_Display(5 * 60, "Tip:\nDon't hold the trigger! Quickly \npress and release to prevent \nshielding after wavedashing.");
+    }
+
+    // Check for slow airdodge landing after full hop
+    if (hmn_data->state_id == ASID_LANDINGFALLSPECIAL
+            && hmn_data->TM.state_frame == 0
+            && hmn_data->TM.state_prev[0] == ASID_ESCAPEAIR
+            && hmn_data->TM.state_prev_frames[0] > 3 // slow to hit ground from airdodge
+            && hmn_data->TM.state_prev_frames[1] < 5 // slightly late airdodge timing
+            && event_data->wd_angle > 0              // ignore horizontal airdodge
+            && !event_data->short_hop)               // full hop
+    {
+        if (event_data->tip.short_hop++ % 8 == 2)
+            event_vars->Tip_Display(5 * 60, "Tip:\nUse short hop for wavedash!\nit can help you land faster\nwhen you airdodge late.");
     }
 }
 

--- a/src/wavedash.h
+++ b/src/wavedash.h
@@ -54,19 +54,9 @@ struct WavedashData
     float wd_maxdstn;
     int timer;
     u8 airdodge_frame;
-    u8 is_airdodge;
-    u8 is_early_airdodge;
-    u8 is_wavedashing;
-    u8 since_wavedash;
     float wd_angle;
     int wd_attempted;
     int wd_succeeded;
-    struct
-    {
-        u16 line_index;
-        Vec2 pos;
-    } restore;
-    GXColor orig_colors[WDFRAMES];
 };
 
 struct WavedashAssets

--- a/src/wavedash.h
+++ b/src/wavedash.h
@@ -55,6 +55,7 @@ struct WavedashData
     int timer;
     u8 airdodge_frame;
     float wd_angle;
+    int short_hop;
     int wd_attempted;
     int wd_succeeded;
 };

--- a/src/wavedash.h
+++ b/src/wavedash.h
@@ -50,6 +50,7 @@ struct WavedashData
     struct
     {
         u8 shield_num;
+        u8 short_hop;
     } tip;
     float wd_maxdstn;
     int timer;


### PR DESCRIPTION
Let me know what you think of the indicator or if it's too distracting. Hopefully the option description plus tip make it clear the utility of short hop wavedashing.

The event should better handle when people wavedash with multiple airdodge inputs.

I got rid of the auto reset because I always found it jarring. Sometimes you want to goof off and move around while not wavedashing.